### PR TITLE
Us the natural precision of 64-bits integer in halStats/coverage

### DIFF
--- a/stats/impl/halStatsMain.cpp
+++ b/stats/impl/halStatsMain.cpp
@@ -837,7 +837,7 @@ void printCoverage(ostream& os, AlignmentConstPtr alignment,
     vector <hal_size_t> *histogram = histIt->second;
     for(hal_size_t i = 0; i < maxHistLength; i++) {
       if (i < histogram->size()) {
-        os << ", " << (double) histogram->at(i);
+        os << ", " << histogram->at(i);
       } else {
         os << ", " << 0;
       }
@@ -979,7 +979,7 @@ static void printAllCoverage(ostream& os, AlignmentConstPtr alignment)
     vector <hal_size_t> *histogram = histIt->second;
     for(hal_size_t i = 0; i < maxHistLength; i++) {
       if (i < histogram->size()) {
-        os << ", " << (double) histogram->at(i);
+        os << ", " << histogram->at(i);
       } else {
         os << ", " << 0;
       }


### PR DESCRIPTION
Otherwise the number of significant digits is too low to cater for mammalian-sized genomes
```
Genome, sitesCovered1Times, sitesCovered2Times, sitesCovered3Times, sitesCovered4Times, sitesCovered5Times,
MusDBA2J_1509, 2.60617e+09, 1.51739e+08, 7.5096e+07, 5.15233e+07, 3.88259e+07,
MusAKRJ_1509, 2.27868e+09, 1.44026e+08, 6.70387e+07, 4.49407e+07, 3.34343e+07,
MusWSBEiJ_1509, 2.22488e+09, 1.22558e+08, 5.47377e+07, 3.4816e+07, 2.45331e+07,
MusCASTEiJ_1509, 2.20011e+09, 1.22092e+08, 5.53258e+07, 3.59784e+07, 2.6238e+07,
```