### PR TITLE
Expose maxBlockLength option to halGetMAF

### DIFF
--- a/chain/impl/halBlockViz.cpp
+++ b/chain/impl/halBlockViz.cpp
@@ -442,6 +442,7 @@ extern "C" hal_int_t halGetMAF(FILE* outFile,
                                hal_int_t tStart, 
                                hal_int_t tEnd,
                                int maxRefGap,
+                               int maxBlockLength,
                                int doDupes,
                                char **errStr)
 {
@@ -488,6 +489,7 @@ extern "C" hal_int_t halGetMAF(FILE* outFile,
     mafExport.setNoDupes(doDupes == 0);
     mafExport.setUcscNames(true);
     mafExport.setMaxRefGap(hal_size_t(maxRefGap));
+    mafExport.setMaxBlockLength(hal_index_t(maxBlockLength));
 
     mafExport.convertSegmentedSequence(mafBuffer, alignment, tGenome, 
                                        absStart, 1 + absEnd - absStart,

--- a/chain/inc/halBlockViz.h
+++ b/chain/inc/halBlockViz.h
@@ -306,6 +306,7 @@ hal_int_t halGetMAF(FILE* outFile,
                     hal_int_t tStart, 
                     hal_int_t tEnd,
                     int maxRefGap,
+                    int maxBlockLength,
                     int doDupes,
                     char **errStr);
 

--- a/chain/test/blockVizMaf.c
+++ b/chain/test/blockVizMaf.c
@@ -104,6 +104,7 @@ int main(int argc, char** argv)
                               args.tStart,
                               args.tEnd,
                               0, // maxRefGap
+                              0, // maxBlockLength
                               args.doDupes,
                               NULL);
 


### PR DESCRIPTION
By default, maxBlockLength is 1kb