### PR TITLE
updated parameters for hal2synteny; added README.md for synteny blocks

### DIFF
--- a/synteny/README.md
+++ b/synteny/README.md
@@ -1,0 +1,36 @@
+DAG-based Reconstruction of Synteny Blocks
+=====
+
+In order to build a set of most continuous synteny blocks covering as much of genomes as possible we build a graph and apply the algorithm:
+    
+1. Initialize weight labels of vertices and edges:
+    
+* initial weight of each vertex is initialized as the size of the corresponding alignment block
+    
+* the weight of each edge coming into a vertex i equals to the length of the corresponding alignment block (initial weight of the vertex i)
+    
+* for each vertex A consider its possible candidate blocks (descendants), update weight of each descendant vertex B in case the weight of an edge coming into B + weight of the previous vertex A is greater than weight of B; if the weight was changed update the id of the previous vertex
+    
+2. Find the vertex with maximal weight and trace back
+    
+3. Remove the vertices that comprise the best path from the graph
+    
+4. If not all vertices are in some paths then go to 2
+
+Sample Usage
+-----
+* Create synteny blocks in psl format for the alignment cactus.hal including genomes Genom1 and Genome2
+
+    `hal2synteny cactus.hal out.psl --queryGenome Genome2 --targetGenome Genome1 --maxAnchorDistance 1000000 --minBlockSize 1000000`
+
+* Create synteny blocks in psl format just for query chromosome chrA 
+
+    `hal2synteny cactus.hal out.psl --queryGenome Genome2 --targetGenome Genome1 --queryChromosome chrA --maxAnchorDistance 1000000 --minBlockSize 1000000`
+
+Code Contributors
+-----
+* Ksenia Krasheninnikova (Theodosius Dobzhansky Center for Genome Bioinformatics)
+* Joel Armstrong (UCSC)
+* Mark Diekhans (UCSC)
+
+

--- a/synteny/impl/hal2psl.cpp
+++ b/synteny/impl/hal2psl.cpp
@@ -41,11 +41,12 @@ std::vector<PslBlock> hal::Hal2Psl::convert2psl(hal::AlignmentConstPtr alignment
         hal::SequenceIteratorConstPtr seqIt = srcGenome->getSequenceIterator();
         hal::SequenceIteratorConstPtr seqEnd = srcGenome->getSequenceEndIterator();
         for (; !seqIt->equals(seqEnd); seqIt->toNext()) {
+          //std::cout << "aa" << srcChrom << std::endl;
           _outBedLines.clear();
           _srcSequence = seqIt->getSequence(); 
           auto chrName = _srcSequence->getName(); 
-          if (srcChrom != chrName) {continue;}
-          //else {std::cout << chrName << std::endl;}
+          if (srcChrom != "\"\""  && srcChrom != chrName) {continue;}
+          //else {std::cout << srcChrom << std::endl;}
           _bedLine._start = 0;
           _bedLine._end = _srcSequence->getSequenceLength(); 
           _mappedBlocks.clear();

--- a/synteny/impl/main.cpp
+++ b/synteny/impl/main.cpp
@@ -54,7 +54,7 @@ hal::AlignmentConstPtr openAlignmentOrThrow(const std::string& halFile,
  void validateInputOrThrow(const std::string& queryGenomeName,
                                 const std::string& targetGenomeName,
                                     const std::string& queryChromosome) {
-      if (queryGenomeName == "\"\"" || targetGenomeName == "\"\"" || queryChromosome == "\"\""){
+      if (queryGenomeName == "\"\"" || targetGenomeName == "\"\"" ){
         throw hal_exception("--queryGenome and --targetGenome and --queryChromosome must be"
                           "specified");
         }
@@ -101,15 +101,15 @@ int main(int argc, char *argv[]) {
     
     
     auto hal2psl = hal::Hal2Psl();
-    //std::cout << "reading hal " << std::endl;                  
+    std::cout << "reading hal " << std::endl;                  
     auto blocks = hal2psl.convert2psl(alignment, queryGenome,
                         targetGenome, queryChromosome);
     
 
-    //std::cout << "merging "  << blocks.size() << " blocks"<< std::endl;                  
+    std::cout << "merging "  << blocks.size() << " blocks"<< std::endl;                  
     auto merged_blocks = dag_merge(blocks, 
                             minBlockSize, maxAnchorDistance);
-    //std::cout << "writing psl "   << std::endl;                  
+    std::cout << "writing psl "   << std::endl;                  
     psl_io::write_psl(merged_blocks, outPslPath);
     }
     catch(std::exception& e)


### PR DESCRIPTION
Hello, 

I added an option to get synteny blocks for the whole query genome, which is helpful for small genomes. Also, some explanation of how the method works is provided in README.md.

Could you consider it for merging into master, please?

Thanks!

