### PR TITLE
Traverse insertions along - strand if inserted on - strand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libhdf5-7 libhdf5-dev; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install hdf5 || echo "a brew error code when installing gcc is expected"; fi
   - git clone https://github.com/ComparativeGenomicsToolkit/sonLib.git
-  - sudo pip install newick attrs pytest toil
+  - sudo pip install --upgrade pip requests pathlib2
+  - sudo pip install --ignore-installed --upgrade six
+  - sudo pip install --upgrade newick attrs pytest toil
 install:
   - sh -c 'cd sonLib && make'
 script:

--- a/api/impl/halColumnIterator.cpp
+++ b/api/impl/halColumnIterator.cpp
@@ -267,17 +267,17 @@ void ColumnIterator::recursiveUpdate(bool init) {
         // otherwise, we scan forward from last visisted column
         else {
             assert(linkTopIt->_it.get() != NULL);
-            bool rev = linkTopIt->_it->getReversed();
-            if (rev == true) {
-                linkTopIt->_it->toReverseInPlace();
-            }
-            assert(linkTopIt->_it->getReversed() == false);
 
             // catch up to nextfreeindex
             linkTopIt->_it->slice(0, 0);
             while (linkTopIt->_it->overlaps(_stack.top()->_index) == false) {
                 linkTopIt->_it->toRight();
             }
+            bool rev = linkTopIt->_it->getReversed();
+            if (rev == true) {
+                linkTopIt->_it->toReverseInPlace();
+            }
+            assert(linkTopIt->_it->getReversed() == false);
             hal_size_t offset = (hal_size_t)abs(_stack.top()->_index - linkTopIt->_it->getStartPosition());
             linkTopIt->_it->slice(offset, linkTopIt->_it->getLength() - offset - 1);
             linkTopIt->_dna->jumpTo(_stack.top()->_index);
@@ -316,17 +316,17 @@ void ColumnIterator::recursiveUpdate(bool init) {
             }
         } else {
             assert(linkBotIt->_it.get() != NULL);
-            bool rev = linkBotIt->_it->getReversed();
-            if (rev == true) {
-                linkBotIt->_it->toReverseInPlace();
-            }
-            assert(linkBotIt->_it->getReversed() == false);
 
             // catch up to nextfreeindex
             linkBotIt->_it->slice(0, 0);
             while (linkBotIt->_it->overlaps(_stack.top()->_index) == false) {
                 linkBotIt->_it->toRight();
             }
+            bool rev = linkBotIt->_it->getReversed();
+            if (rev == true) {
+                linkBotIt->_it->toReverseInPlace();
+            }
+            assert(linkBotIt->_it->getReversed() == false);
             hal_size_t offset = (hal_size_t)abs(_stack.top()->_index - linkBotIt->_it->getStartPosition());
             linkBotIt->_it->slice(offset, linkBotIt->_it->getLength() - offset - 1);
             linkBotIt->_dna->jumpTo(_stack.top()->_index);

--- a/api/impl/halColumnIterator.cpp
+++ b/api/impl/halColumnIterator.cpp
@@ -120,8 +120,7 @@ void ColumnIterator::toRight() {
     } while (_break == true);
 
     // push the indel stack.
-    _stack.pushStackReversed(_deletionStack);
-    _stack.pushStack(_insertionStack);
+    _stack.pushStack(_indelStack);
 
     // clean stack again
     nextFreeIndex();
@@ -371,7 +370,10 @@ bool ColumnIterator::handleDeletion(const TopSegmentIteratorPtr &inputTopSegIt) 
 
                 BottomSegmentIteratorPtr botSegIt = parent->getBottomSegmentIterator(0);
                 botSegIt->toParent(inputTopSegIt);
-                _deletionStack.push(botSegIt->getBottomSegment()->getSequence(), deletedRange.first, deletedRange.second, botSegIt->getReversed());
+                cout << "adding deletion child: " << _top->getGenome()->getName() << " parent: " << botSegIt->getGenome()->getName() << " seq: " << botSegIt->getBottomSegment()->getSequence()->getName() << ":" << deletedRange.first - botSegIt->getBottomSegment()->getSequence()->getStartPosition() << "-" << deletedRange.second - botSegIt->getBottomSegment()->getSequence()->getStartPosition() << " top reversed: " << inputTopSegIt->getReversed() << " bot reversed: " << botSegIt->getReversed() << endl;
+                if (_indelStack.size() == 0) {
+                    _indelStack.push(botSegIt->getBottomSegment()->getSequence(), deletedRange.first, deletedRange.second, botSegIt->getReversed());
+                }
 
                 return true;
             }
@@ -394,7 +396,10 @@ bool ColumnIterator::handleInsertion(const TopSegmentIteratorPtr &inputTopSegIt)
                 _rearrangement->getLength() + _stack.top()->_cumulativeSize <= _maxInsertionLength) {
                 pair<hal_index_t, hal_index_t> insertedRange = _rearrangement->getInsertedRange();
                 assert((hal_size_t)(insertedRange.second - insertedRange.first) == _rearrangement->getLength() - 1);
-                _insertionStack.push(_top->getTopSegment()->getSequence(), insertedRange.first, insertedRange.second, reversed);
+                cout << "adding insertion genome: " << _top->getGenome()->getName() << " seq: " << _top->getTopSegment()->getSequence()->getName() << ":" << insertedRange.first - _top->getTopSegment()->getSequence()->getStartPosition() << "-" << insertedRange.second - _top->getTopSegment()->getSequence()->getStartPosition() << " top reversed: " << inputTopSegIt->getReversed() << endl;
+                if (_indelStack.size() == 0) {
+                    _indelStack.push(_top->getTopSegment()->getSequence(), insertedRange.first, insertedRange.second, reversed);
+                }
             }
         }
     }

--- a/api/impl/halColumnIterator.cpp
+++ b/api/impl/halColumnIterator.cpp
@@ -18,7 +18,7 @@ using namespace hal;
 ColumnIterator::ColumnIterator(const Genome *reference, const set<const Genome *> *targets, hal_index_t columnIndex,
                                hal_index_t lastColumnIndex, hal_size_t maxInsertLength, bool noDupes, bool noAncestors,
                                bool reverseStrand, bool unique, bool onlyOrthologs)
-    : _maxInsertionLength(maxInsertLength), _noDupes(noDupes), _noAncestors(noAncestors), _reversed(reverseStrand),
+    : _maxInsertionLength(maxInsertLength), _noDupes(noDupes), _noAncestors(noAncestors),
       _treeCache(NULL), _unique(unique), _onlyOrthologs(onlyOrthologs) {
     assert(columnIndex >= 0 && lastColumnIndex >= columnIndex && lastColumnIndex < (hal_index_t)reference->getSequenceLength());
 
@@ -52,7 +52,7 @@ ColumnIterator::ColumnIterator(const Genome *reference, const set<const Genome *
     }
 
     // note columnIndex in genome (not sequence) coordinates
-    _stack.push(sequence, columnIndex, lastColumnIndex);
+    _stack.push(sequence, columnIndex, lastColumnIndex, reverseStrand);
 
     toRight();
 }
@@ -101,12 +101,18 @@ void ColumnIterator::toRight() {
         recursiveUpdate(init);
 
         // move the index right
-        ++_stack.top()->_index;
+        if (_stack.top()->_reversed) {
+            _stack.top()->_index--;
+        } else {
+            _stack.top()->_index++;
+        }
 
         // jump to next sequence in genome if necessary
         const Sequence *seq = _stack.top()->_sequence;
-        if (_stack.size() == 1 && _stack.top()->_index >= (hal_index_t)(seq->getStartPosition() + seq->getSequenceLength()) &&
-            _stack.top()->_index < (hal_index_t)(seq->getGenome()->getSequenceLength())) {
+        if (_stack.size() == 1 &&
+            (_stack.top()->_index < seq->getStartPosition() ||
+             (_stack.top()->_index >= (hal_index_t)(seq->getStartPosition() + seq->getSequenceLength()) &&
+            _stack.top()->_index < (hal_index_t)(seq->getGenome()->getSequenceLength())))) {
             _stack.top()->_sequence = seq->getGenome()->getSequenceBySite(_stack.top()->_index);
             assert(_stack.top()->_sequence != NULL);
             _ref = _stack.top()->_sequence;
@@ -159,7 +165,7 @@ void ColumnIterator::toSite(hal_index_t columnIndex, hal_index_t lastColumnIndex
 }
 
 bool ColumnIterator::lastColumn() const {
-    return _stack.size() == 1 && _stack.top()->_index > _stack.top()->_lastIndex;
+    return _stack.size() == 1 && _stack.top()->pastEnd();
 }
 
 const Genome *ColumnIterator::getReferenceGenome() const {
@@ -253,7 +259,7 @@ void ColumnIterator::recursiveUpdate(bool init) {
             linkTopIt->_it = refSequence->getTopSegmentIterator();
             linkTopIt->_it->toSite(_stack.top()->_index, true);
             linkTopIt->_dna = refGenome->getDnaIterator(_stack.top()->_index);
-            if (_reversed == true) {
+            if (_stack.top()->_reversed) {
                 linkTopIt->_it->toReverseInPlace();
                 linkTopIt->_dna->toReverse();
             }
@@ -262,7 +268,6 @@ void ColumnIterator::recursiveUpdate(bool init) {
         else {
             assert(linkTopIt->_it.get() != NULL);
             bool rev = linkTopIt->_it->getReversed();
-            assert(rev == _reversed);
             if (rev == true) {
                 linkTopIt->_it->toReverseInPlace();
             }
@@ -281,7 +286,6 @@ void ColumnIterator::recursiveUpdate(bool init) {
                 linkTopIt->_it->toReverseInPlace();
             }
         }
-        assert(linkTopIt->_it->getReversed() == _reversed && linkTopIt->_dna->getReversed() == _reversed);
         assert(linkTopIt->_it->getStartPosition() == linkTopIt->_dna->getArrayIndex());
         assert(linkTopIt->_dna->getArrayIndex() == _stack.top()->_index);
         assert(_stack.top()->_index <= _stack.top()->_lastIndex);
@@ -306,14 +310,13 @@ void ColumnIterator::recursiveUpdate(bool init) {
             linkBotIt->_it = refSequence->getBottomSegmentIterator();
             linkBotIt->_it->toSite(_stack.top()->_index, true);
             linkBotIt->_dna = refGenome->getDnaIterator(_stack.top()->_index);
-            if (_reversed == true) {
+            if (_stack.top()->_reversed) {
                 linkBotIt->_it->toReverseInPlace();
                 linkBotIt->_dna->toReverse();
             }
         } else {
             assert(linkBotIt->_it.get() != NULL);
             bool rev = linkBotIt->_it->getReversed();
-            assert(rev == _reversed);
             if (rev == true) {
                 linkBotIt->_it->toReverseInPlace();
             }
@@ -333,7 +336,6 @@ void ColumnIterator::recursiveUpdate(bool init) {
             }
         }
 
-        assert(linkBotIt->_it->getReversed() == _reversed && linkBotIt->_dna->getReversed() == _reversed);
         assert(linkBotIt->_it->getStartPosition() == linkBotIt->_dna->getArrayIndex());
         assert(linkBotIt->_dna->getArrayIndex() == _stack.top()->_index);
 
@@ -399,7 +401,7 @@ bool ColumnIterator::handleInsertion(const TopSegmentIteratorPtr &inputTopSegIt)
                 pair<hal_index_t, hal_index_t> insertedRange = _rearrangement->getInsertedRange();
                 assert((hal_size_t)(insertedRange.second - insertedRange.first) == _rearrangement->getLength() - 1);
 
-                _indelStack.push(_top->getTopSegment()->getSequence(), insertedRange.first, insertedRange.second);
+                _indelStack.push(_top->getTopSegment()->getSequence(), insertedRange.first, insertedRange.second, reversed);
             }
         }
     }

--- a/api/impl/halColumnIterator.cpp
+++ b/api/impl/halColumnIterator.cpp
@@ -359,6 +359,11 @@ bool ColumnIterator::handleDeletion(const TopSegmentIteratorPtr &inputTopSegIt) 
         _top->copy(inputTopSegIt);
         bool reversed = _top->getReversed();
         if (reversed == true) {
+            // We need to identify the deletion from the *left* breakpoint on
+            // the positive strand. That means the *right* breakpoint when on
+            // the negative strand. Therefore, we go right (i.e. left according
+            // to the positive strand) when checking the breakpoint.
+            _top->toRight();
             _top->toReverse();
         }
         // only handle a deletion if we are immediately left of the breakpoint
@@ -373,8 +378,8 @@ bool ColumnIterator::handleDeletion(const TopSegmentIteratorPtr &inputTopSegIt) 
                 assert((hal_size_t)(deletedRange.second - deletedRange.first) == _rearrangement->getLength() - 1);
 
                 BottomSegmentIteratorPtr botSegIt = parent->getBottomSegmentIterator(0);
-                botSegIt->toParent(_top);
-                _indelStack.push(botSegIt->getBottomSegment()->getSequence(), deletedRange.first, deletedRange.second, reversed);
+                botSegIt->toParent(inputTopSegIt);
+                _indelStack.push(botSegIt->getBottomSegment()->getSequence(), deletedRange.first, deletedRange.second, botSegIt->getReversed());
 
                 return true;
             }

--- a/api/impl/halColumnIterator.cpp
+++ b/api/impl/halColumnIterator.cpp
@@ -374,7 +374,7 @@ bool ColumnIterator::handleDeletion(const TopSegmentIteratorPtr &inputTopSegIt) 
 
                 BottomSegmentIteratorPtr botSegIt = parent->getBottomSegmentIterator(0);
                 botSegIt->toParent(_top);
-                _indelStack.push(botSegIt->getBottomSegment()->getSequence(), deletedRange.first, deletedRange.second);
+                _indelStack.push(botSegIt->getBottomSegment()->getSequence(), deletedRange.first, deletedRange.second, reversed);
 
                 return true;
             }

--- a/api/impl/halColumnIterator.cpp
+++ b/api/impl/halColumnIterator.cpp
@@ -120,7 +120,8 @@ void ColumnIterator::toRight() {
     } while (_break == true);
 
     // push the indel stack.
-    _stack.pushStack(_indelStack);
+    _stack.pushStackReversed(_deletionStack);
+    _stack.pushStack(_insertionStack);
 
     // clean stack again
     nextFreeIndex();
@@ -357,15 +358,6 @@ void ColumnIterator::recursiveUpdate(bool init) {
 bool ColumnIterator::handleDeletion(const TopSegmentIteratorPtr &inputTopSegIt) {
     if (_maxInsertionLength > 0 && inputTopSegIt->tseg()->hasParent() == true) {
         _top->copy(inputTopSegIt);
-        bool reversed = _top->getReversed();
-        if (reversed == true) {
-            // We need to identify the deletion from the *left* breakpoint on
-            // the positive strand. That means the *right* breakpoint when on
-            // the negative strand. Therefore, we go right (i.e. left according
-            // to the positive strand) when checking the breakpoint.
-            _top->toRight();
-            _top->toReverse();
-        }
         // only handle a deletion if we are immediately left of the breakpoint
         if (_top->getEndOffset() == 0) {
             const Genome *genome = _top->getTopSegment()->getGenome();
@@ -379,7 +371,7 @@ bool ColumnIterator::handleDeletion(const TopSegmentIteratorPtr &inputTopSegIt) 
 
                 BottomSegmentIteratorPtr botSegIt = parent->getBottomSegmentIterator(0);
                 botSegIt->toParent(inputTopSegIt);
-                _indelStack.push(botSegIt->getBottomSegment()->getSequence(), deletedRange.first, deletedRange.second, botSegIt->getReversed());
+                _deletionStack.push(botSegIt->getBottomSegment()->getSequence(), deletedRange.first, deletedRange.second, botSegIt->getReversed());
 
                 return true;
             }
@@ -397,16 +389,12 @@ bool ColumnIterator::handleInsertion(const TopSegmentIteratorPtr &inputTopSegIt)
             _rearrangement->setAtomic(true);
             _top->slice(0, 0);
             _top->toRight();
-            if (reversed == true) {
-                _top->toReverse();
-            }
             assert(_rearrangement->getAtomic() == true);
             if (_rearrangement->identifyInsertionFromLeftBreakpoint(_top) == true &&
                 _rearrangement->getLength() + _stack.top()->_cumulativeSize <= _maxInsertionLength) {
                 pair<hal_index_t, hal_index_t> insertedRange = _rearrangement->getInsertedRange();
                 assert((hal_size_t)(insertedRange.second - insertedRange.first) == _rearrangement->getLength() - 1);
-
-                _indelStack.push(_top->getTopSegment()->getSequence(), insertedRange.first, insertedRange.second, reversed);
+                _insertionStack.push(_top->getTopSegment()->getSequence(), insertedRange.first, insertedRange.second, reversed);
             }
         }
     }

--- a/api/impl/halRearrangement.cpp
+++ b/api/impl/halRearrangement.cpp
@@ -56,12 +56,10 @@ hal_size_t Rearrangement::getNumContainedGapBases() const {
 }
 
 TopSegmentIteratorPtr Rearrangement::getLeftBreakpoint() const {
-    assert(_cur->getReversed() == false);
     return _cur->getLeft();
 }
 
 TopSegmentIteratorPtr Rearrangement::getRightBreakpoint() const {
-    assert(_cur->getReversed() == false);
     return _cur->getRight();
 }
 
@@ -135,7 +133,6 @@ bool Rearrangement::identifyFromLeftBreakpoint(TopSegmentIteratorPtr topSegment)
 }
 
 bool Rearrangement::identifyDeletionFromLeftBreakpoint(TopSegmentIteratorPtr topSegment) {
-    assert(topSegment->getReversed() == false);
     if (scanDeletionCycle(topSegment) == true && _leftParent->hasChild() == false) {
         _id = Deletion;
         return true;
@@ -159,7 +156,6 @@ pair<hal_index_t, hal_index_t> Rearrangement::getDeletedRange() const {
 }
 
 bool Rearrangement::identifyInsertionFromLeftBreakpoint(TopSegmentIteratorPtr topSegment) {
-    assert(topSegment->getReversed() == false);
     if (scanInsertionCycle(topSegment) == true && _cur->hasParent() == false) {
         _id = Insertion;
         return true;

--- a/api/inc/halColumnIterator.h
+++ b/api/inc/halColumnIterator.h
@@ -155,8 +155,6 @@ namespace hal {
         std::set<const Genome *> _scope;
         ColumnIteratorStack _stack;
         ColumnIteratorStack _indelStack;
-        ColumnIteratorStack _insertionStack;
-        ColumnIteratorStack _deletionStack;
         const Sequence *_ref;
 
         RearrangementPtr _rearrangement;

--- a/api/inc/halColumnIterator.h
+++ b/api/inc/halColumnIterator.h
@@ -161,7 +161,6 @@ namespace hal {
         hal_size_t _maxInsertionLength;
         bool _noDupes;
         bool _noAncestors;
-        bool _reversed;
 
         ColumnMap _colMap;
         TopSegmentIteratorPtr _top;

--- a/api/inc/halColumnIterator.h
+++ b/api/inc/halColumnIterator.h
@@ -155,6 +155,8 @@ namespace hal {
         std::set<const Genome *> _scope;
         ColumnIteratorStack _stack;
         ColumnIteratorStack _indelStack;
+        ColumnIteratorStack _insertionStack;
+        ColumnIteratorStack _deletionStack;
         const Sequence *_ref;
 
         RearrangementPtr _rearrangement;

--- a/api/inc/halColumnIteratorStack.h
+++ b/api/inc/halColumnIteratorStack.h
@@ -126,6 +126,12 @@ namespace hal {
             }
             otherStack._stack.clear();
         }
+        void pushStackReversed(ColumnIteratorStack &otherStack) {
+            for (int64_t i = otherStack.size() - 1; i >= 0; --i) {
+                _stack.push_back(otherStack[i]);
+            }
+            otherStack._stack.clear();
+        }
         void popDelete() {
             delete _stack.back();
             _stack.pop_back();

--- a/api/inc/halColumnIteratorStack.h
+++ b/api/inc/halColumnIteratorStack.h
@@ -46,13 +46,21 @@ namespace hal {
 
         class Entry {
           public:
-            Entry(const Sequence *seq, hal_index_t first, hal_index_t index, hal_index_t last, hal_size_t size)
-                : _sequence(seq), _firstIndex(first), _index(index), _lastIndex(last), _cumulativeSize(size) {
+            Entry(const Sequence *seq, hal_index_t first, hal_index_t index, hal_index_t last, hal_size_t size, bool reversed)
+                : _sequence(seq), _firstIndex(first), _index(index), _lastIndex(last), _cumulativeSize(size), _reversed(reversed) {
                 _top._entry = this;
                 _bottom._entry = this;
             }
             ~Entry() {
                 freeLinks();
+            }
+
+            bool pastEnd() const {
+                if (_reversed) {
+                    return _index < _firstIndex;
+                } else {
+                    return _index > _lastIndex;
+                }
             }
 
             LinkedTopIterator *newTop() {
@@ -95,20 +103,21 @@ namespace hal {
             LinkedBottomIterator _bottom;
             std::vector<LinkedTopIterator *> _topLinks;
             std::vector<LinkedBottomIterator *> _bottomLinks;
+            bool _reversed;
         };
 
       public:
         ~ColumnIteratorStack() {
             clear();
         }
-        void push(const Sequence *ref, hal_index_t index, hal_index_t lastIndex) {
+        void push(const Sequence *ref, hal_index_t index, hal_index_t lastIndex, bool reversed = false) {
             assert(lastIndex >= index);
             assert(ref != NULL);
             hal_size_t cumulative = 0;
             if (_stack.size() > 0) {
                 cumulative = top()->_cumulativeSize + lastIndex - index + 1;
             }
-            Entry *entry = new Entry(ref, index, index, lastIndex, cumulative);
+            Entry *entry = new Entry(ref, index, reversed ? lastIndex : index, lastIndex, cumulative, reversed);
             _stack.push_back(entry);
         }
         void pushStack(ColumnIteratorStack &otherStack) {

--- a/api/inc/halSegmentedSequence.h
+++ b/api/inc/halSegmentedSequence.h
@@ -71,7 +71,7 @@ namespace hal {
          * @param noDupes Don't follow paralogy edges
          * @param noAncestors Don't report any non-leaf nodes in output
          * @param reverseStrand Map from reverse strand of this sequence
-         * (but still in a left-to-right direction of forward strand)
+         * (and in the opposite direction of forward strand)
          * @param unique calls to toRight() will automatically skip
          * over bases in the reference sequence that have already been
          * seen in an alignment column (ie homologous to already visited

--- a/extract/impl/hal4dExtract.cpp
+++ b/extract/impl/hal4dExtract.cpp
@@ -59,7 +59,7 @@ void Extract4d::visitLine() {
 
 // Check if the 4d site is still a 4d site in all aligned regions.
 static bool is4dSiteConserved(const Sequence *sequence, hal_index_t pos, bool reversed) {
-    ColumnIteratorPtr colIt = sequence->getColumnIterator(NULL, 0, pos, NULL_INDEX, false, true, reversed);
+    ColumnIteratorPtr colIt = sequence->getColumnIterator(NULL, 0, pos, pos, false, true, reversed);
     bool isConserved = true;
     const ColumnIterator::ColumnMap *colMap = colIt->getColumnMap();
     for (ColumnIterator::ColumnMap::const_iterator colMapIt = colMap->begin(); colMapIt != colMap->end(); ++colMapIt) {


### PR DESCRIPTION
Fixes ComparativeGenomicsToolkit/cactus#83.

The column iterator (when allowing insertions) would always traverse insertions left-to-right, regardless of if the insertion occurred in an ancestral genome which was being traversed right-to-left.

NB: As a side effect this changes the semantics of constructing a
"reversed" column iterator--it will now go properly go from
right-to-left instead of left-to-right. Shouldn't be a problem, but
needs to be looked into before merging.