### PR TITLE
Fix hdf5 "no write intent on file" error from halRenameGenomes

### DIFF
--- a/modify/halRenameGenomes.cpp
+++ b/modify/halRenameGenomes.cpp
@@ -26,7 +26,7 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    AlignmentPtr alignment(openHalAlignment(halPath, &optionsParser));
+    AlignmentPtr alignment(openHalAlignment(halPath, &optionsParser, WRITE_ACCESS | READ_ACCESS));
     map<string, string> renameMap = ingestRenameFile(renamePath);
 
     // Check that the alignment has all the old genome names, and none


### PR DESCRIPTION
Currently, if you run halRenameGenomes, you get the following error:

```bash
halRenameGenomes test.hal rename.txt
Renaming N67-2-2-1 to N67221
HDF5-DIAG: Error detected in HDF5 (1.8.17) thread 0:
  #000: H5L.c line 349 in H5Lmove(): unable to move link
    major: Links
    minor: Can't move object
  #001: H5L.c line 2704 in H5L_move(): unable to find link
    major: Symbol table
    minor: Object not found
  #002: H5Gtraverse.c line 861 in H5G_traverse(): internal path traversal failed
    major: Symbol table
    minor: Object not found
  #003: H5Gtraverse.c line 641 in H5G_traverse_real(): traversal operator failed
    major: Symbol table
    minor: Callback failed
  #004: H5L.c line 2564 in H5L_move_cb(): unable to follow symbolic link
    major: Symbol table
    minor: Object not found
  #005: H5Gtraverse.c line 861 in H5G_traverse(): internal path traversal failed
    major: Symbol table
    minor: Object not found
  #006: H5Gtraverse.c line 641 in H5G_traverse_real(): traversal operator failed
    major: Symbol table
    minor: Callback failed
  #007: H5L.c line 2442 in H5L_move_dest_cb(): unable to create new link to object
    major: Links
    minor: Unable to initialize object
  #008: H5Gobj.c line 600 in H5G_obj_insert(): unable to insert entry into symbol table
    major: Symbol table
    minor: Unable to insert object
  #009: H5Gstab.c line 338 in H5G__stab_insert(): unable to insert the name
    major: Datatype
    minor: Unable to initialize object
  #010: H5Gstab.c line 280 in H5G__stab_insert_real(): unable to protect symbol table heap
    major: Symbol table
    minor: Protected metadata error
  #011: H5HL.c line 468 in H5HL_protect(): unable to load heap prefix
    major: Heap
    minor: Unable to protect metadata
  #012: H5AC.c line 1211 in H5AC_protect(): no write intent on file
    major: Object cache
    minor: Bad value
terminate called after throwing an instance of 'H5::GroupIException'
Aborted (core dumped)
```

The other rename utility, halRenameSequences gives WRITE_ACCESS when opening the alignment file, so I made the same fix to halRenameGenomes, and now it works.

Thanks so much for the HAL utility and the Comparative Genomics Tools.  They are very useful to me in my work.