### PR TITLE
Python3 fixes for hal2assemblyHub

### DIFF
--- a/assemblyHub/alignabilityTrack.py
+++ b/assemblyHub/alignabilityTrack.py
@@ -8,17 +8,17 @@
 """Creating Alignability (Alignment Depth) track for the hubs
 """
 import os
-from sonLib.bioio import system  
-from jobTree.scriptTree.target import Target
+from sonLib.bioio import system
+from toil.job import Job
 
-class GetAlignability( Target ):
+class GetAlignability( Job ):
     def __init__(self, genomedir, genome, halfile):
-        Target.__init__(self)
+        Job.__init__(self)
         self.genomedir = genomedir
         self.genome = genome
         self.halfile = halfile
 
-    def run(self):
+    def run(self, fileStore):
         outfile = os.path.join(self.genomedir, "%s.alignability.bw" %self.genome)
         tempwig = os.path.join(self.genomedir, "%s.alignability.wig" %self.genome)
         system("halAlignmentDepth %s %s > %s" %(self.halfile, self.genome, tempwig))
@@ -49,8 +49,8 @@ def writeTrackDb_alignability(f, genome, genomeCount):
 
 def addAlignabilityOptions(parser):
     from optparse import OptionGroup
-    #group = OptionGroup(parser, "ALIGNABILITY", "Alignability: the number of genomes aligned to each position.")
-    group = OptionGroup(parser, "ALIGNABILITY")
-    group.add_option('--alignability', dest='alignability', action='store_true', default=False, help='If specified, make Alignability (aka Alignment Depth) tracks. Default=%default')
-    parser.add_option_group(group)
+    #group = parser.add_argument_group("ALIGNABILITY", "Alignability: the number of genomes aligned to each position.")
+    group = parser.add_argument_group("ALIGNABILITY")
+    group.add_argument('--alignability', dest='alignability', action='store_true', default=False, help='If specified, make Alignability (aka Alignment Depth) tracks. ')
+    group = parser.add_argument_group(group)
 

--- a/assemblyHub/assemblyHubCommon.py
+++ b/assemblyHub/assemblyHubCommon.py
@@ -10,18 +10,18 @@ Objects & functions that are used by multiple assemblyHub modules
 """
 import os, re, time
 from sonLib.bioio import system  
-from jobTree.scriptTree.target import Target
+from toil.job import Job
 
-class MakeAnnotationTracks( Target ):
+class MakeAnnotationTracks( Job ):
     def __init__(self, options, outdir, halfile, genome2seq2len, type):
-        Target.__init__(self)
+        Job.__init__(self)
         self.options = options
         self.outdir = outdir
         self.halfile = halfile
         self.genome2seq2len = genome2seq2len
         self.type = type #type has to be bed or wiggle
 
-    def run(self):
+    def run(self, fileStore):
         #Lift-over Bed/Wiggle annotations of each sample to all other samples
         if self.type == 'bed':
             indirs = self.options.beddirs
@@ -36,17 +36,17 @@ class MakeAnnotationTracks( Target ):
                 bigdir = os.path.join(self.outdir, "liftover%s" %self.type, annotation)
                 if self.type == "wig":
                     from hal.assemblyHub.wigTrack import LiftoverWigFiles
-                    self.addChildTarget( LiftoverWigFiles(indir, self.halfile, self.genome2seq2len, bigdir, self.options.noWigLiftover, self.outdir) )
+                    self.addChild( LiftoverWigFiles(indir, self.halfile, self.genome2seq2len, bigdir, self.options.noWigLiftover, self.outdir) )
                 else:
                     from hal.assemblyHub.bedTrack import LiftoverBedFiles
-                    self.addChildTarget( LiftoverBedFiles(indir, self.halfile, self.genome2seq2len, bigdir, self.options.noBedLiftover, self.options.tabbed, self.outdir, self.options) )
+                    self.addChild( LiftoverBedFiles(indir, self.halfile, self.genome2seq2len, bigdir, self.options.noBedLiftover, self.options.tabbed, self.outdir, self.options) )
 
-class CleanupFiles(Target):
+class CleanupFiles(Job):
     def __init__(self, files):
-        Target.__init__(self)
+        Job.__init__(self)
         self.files = files
 
-    def run(self):
+    def run(self, fileStore):
         if len(self.files) > 0:
             system( "rm -f %s" % " ".join(self.files) ) #cleanup
 

--- a/assemblyHub/bedCommon.py
+++ b/assemblyHub/bedCommon.py
@@ -5,7 +5,7 @@ Mon Oct  7 15:27:23 PDT 2013
 If a gene contains large intron, break it into separate bed entries
 '''
 import sys
-from optparse import OptionParser
+from argparse import ArgumentParser
 from sonLib.bioio import system  
 
 #========= FILTER LONG INTRONS ==========

--- a/assemblyHub/gcPercentTrack.py
+++ b/assemblyHub/gcPercentTrack.py
@@ -9,15 +9,15 @@
 """
 import os
 from sonLib.bioio import system  
-from jobTree.scriptTree.target import Target
+from toil.job import Job
 
-class GetGCpercent( Target ):
+class GetGCpercent( Job ):
     def __init__(self, genomedir, genome):
-        Target.__init__(self)
+        Job.__init__(self)
         self.genomedir = genomedir
         self.genome = genome
 
-    def run(self):
+    def run(self, fileStore):
         twobitfile = os.path.join(self.genomedir, "%s.2bit" %self.genome)
         tempfile = os.path.join(self.genomedir, "%s.gc.wigVarStep.gz" %self.genome)
         cmd = "hgGcPercent -wigOut -doGaps -file=stdout -win=5 -verbose=0 %s %s | gzip -c > %s" %(self.genome, twobitfile, tempfile)
@@ -51,8 +51,8 @@ def writeTrackDb_gcPercent(f, genome):
 
 def addGcOptions(parser):
     from optparse import OptionGroup
-    #group = OptionGroup(parser, "GC PERCENT", "GC Percent in 5-base Window.")
-    group = OptionGroup(parser, "GC PERCENT")
-    group.add_option('--gcContent', dest='gcContent', action='store_true', default=False, help='If specified, make GC-content tracks. Default=%default')
-    parser.add_option_group(group)
+    #group = parser.add_argument_group("GC PERCENT", "GC Percent in 5-base Window.")
+    group = parser.add_argument_group("GC PERCENT")
+    group.add_argument('--gcContent', dest='gcContent', action='store_true', default=False, help='If specified, make GC-content tracks. ')
+    group = parser.add_argument_group(group)
 

--- a/assemblyHub/prepareHubFiles.py
+++ b/assemblyHub/prepareHubFiles.py
@@ -151,17 +151,17 @@ def readRename(file):
 
 #=========== OPTIONS =============
 def addHubOptions(parser):
-    group = OptionGroup(parser, "HUB INFORMATION")
-    group.add_option('--hub', dest='hubLabel', default='myHub', help='a single-word name of the directory containing the track hub files. Not displayed to hub users. Default=%default')
-    group.add_option('--shortLabel', dest='shortLabel', default='my hub', help='the short name for the track hub. Suggested maximum length is 17 characters. Displayed as the hub name on the Track Hubs page and the track group name on the browser tracks page. Default=%default')
-    group.add_option('--longLabel', dest='longLabel', default='my hub', help='a longer descriptive label for the track hub. Suggested maximum length is 80 characters. Displayed in the description field on the Track Hubs page. Default=%default')
-    group.add_option('--email', dest='email', default='NoEmail', help='the contact to whom questions regarding the track hub should be directed. Default=%default')
-    group.add_option('--genomes', dest='genomes', help='File specified list of genomes to make browser for. If specified, only create browsers for these genomes in the order provided by the list. Otherwise create browsers for all genomes in the input hal file')
-    group.add_option('--rename', dest='rename', help='File that maps halfile genomeNames to names displayed on the browser. Format: <halGenomeName>\\t<genomeNameToDisplayOnBrowser>. Default=%default') 
-    group.add_option('--tree', dest='treeFile', help='Newick binary tree. The order of the tracks and the default track layout will be based on this tree if option "genomes" is not specified. If not specified, try to extract the newick tree from the input halfile.')
-    group.add_option('--url', dest='url', help='Public url of the hub location')
-    group.add_option('--twobitdir', dest='twobitdir', help='Optional. Directory containing the 2bit files of each genomes. Default: extract from the input hal file.')
-    parser.add_option_group(group)
+    group = parser.add_argument_group("HUB INFORMATION")
+    group.add_argument('--hub', dest='hubLabel', default='myHub', help='a single-word name of the directory containing the track hub files. Not displayed to hub users. ')
+    group.add_argument('--shortLabel', dest='shortLabel', default='my hub', help='the short name for the track hub. Suggested maximum length is 17 characters. Displayed as the hub name on the Track Hubs page and the track group name on the browser tracks page. ')
+    group.add_argument('--longLabel', dest='longLabel', default='my hub', help='a longer descriptive label for the track hub. Suggested maximum length is 80 characters. Displayed in the description field on the Track Hubs page. ')
+    group.add_argument('--email', dest='email', default='NoEmail', help='the contact to whom questions regarding the track hub should be directed. ')
+    group.add_argument('--genomes', dest='genomes', help='File specified list of genomes to make browser for. If specified, only create browsers for these genomes in the order provided by the list. Otherwise create browsers for all genomes in the input hal file')
+    group.add_argument('--rename', dest='rename', help='File that maps halfile genomeNames to names displayed on the browser. Format: <halGenomeName>\\t<genomeNameToDisplayOnBrowser>. ') 
+    group.add_argument('--tree', dest='treeFile', help='Newick binary tree. The order of the tracks and the default track layout will be based on this tree if option "genomes" is not specified. If not specified, try to extract the newick tree from the input halfile.')
+    group.add_argument('--url', dest='url', help='Public url of the hub location')
+    group.add_argument('--twobitdir', dest='twobitdir', help='Optional. Directory containing the 2bit files of each genomes. Default: extract from the input hal file.')
+    group = parser.add_argument_group(group)
 
 def checkHubOptions(parser, options):
     if options.genomes:

--- a/assemblyHub/prepareLodFiles.py
+++ b/assemblyHub/prepareLodFiles.py
@@ -71,8 +71,8 @@ def getLod(options, localHalfile, outdir):
         options.lodOpts += '--minCovFrac %f ' % options.lodMinCovFrac
     if options.lodChunk is not None:
         options.lodOpts += '--chunk %d ' % options.lodChunk
-    if int(options.maxThreads) > 1 and (options.lod or len(options.lodOpts) > 0):
-        options.lodOpts += '--numProc %d ' % int(options.maxThreads)
+    if options.maxCores and int(options.maxCores) > 1 and (options.lod or len(options.lodOpts) > 0):
+        options.lodOpts += '--numProc %d ' % int(options.maxCores)
     if len(options.lodOpts) > 0:
         print(options.lodOpts)
         options.lod = True
@@ -97,17 +97,17 @@ def getLodLowestLevel(lodtxtfile):
     return level
 
 def addLodOptions(parser):
-    group = OptionGroup(parser, "LEVEL OF DETAILS", "Level-of-detail (LOD) options.")
-    group.add_option('--lod', dest='lod', action="store_true", default=False, help='If specified, create "level of detail" (lod) hal files and will put the lod.txt at the bigUrl instead of the original hal file. Default=%default')
-    group.add_option('--lodTxtFile', dest='lodtxtfile', help='"hal Level of detail" lod text file. If specified, will put this at the bigUrl instead of the hal file. Default=%default')
-    group.add_option('--lodDir', dest='loddir', help='"hal Level of detail" lod dir. If specified, will put this at the bigUrl instead of the hal file. Default=%default')
-    group.add_option('--lodMaxBlock', dest='lodMaxBlock', type='int', help='Maximum number of blocks to display in a hal level of detail (see halLodInterpolate.py --help for the default value).', default=None)
-    group.add_option('--lodScale', dest='lodScale', type='float', help='Scaling factor between two successive levels of detail (see halLodInterpolate.py --help for the default value).', default=None)
-    group.add_option('--lodMaxDNA', dest='lodMaxDNA', type='int', help='Maximum query length such that its hal level of detail will contain nucleotide information. Default=%default (see halLodInterpolate.py --help for the default value).', default=None)
-    group.add_option('--lodInMemory', dest='lodInMemory', action='store_true', help='Load entire hal file into memory when generating levels of detail instead of using hdf5 cache. Could result in drastic speedup. Default=%default.', default=False)
-    group.add_option('--lodMinSeqFrac', dest='lodMinSeqFrac', type='float', help='Minumum sequence length to sample as fraction of step size for level of detail generation: ie sequences with length <= floor(minSeqFrac * step) are ignored (see halLodExtract --help for default value).', default=None)
-    group.add_option('--lodMinCovFrac', dest='lodMinCovFrac', type='float', help='Minimum fraction of a genome that must be covered by sequences that exceed --minSeqFrac * step.  LODs that would violate this threshold will not be generated (or displayed in  the browser).  This is seen a better than the alternative, which is to produce unreasonably sparse LODs because half the sequences were not sampled (see halLodInterpolate.py --help for default value).', default=None)
-    group.add_option('--lodChunk', dest='lodChunk', type='int', help='HDF5 chunk size for generated levels of detail (see halLodExtract --help for default value).', default=None)
-    #group.add_option('--snpwidth', dest='snpwidth', type='int', default=5000, help='Maximum window size to display SNPs. Default=%default')
-    parser.add_option_group(group)
+    group = parser.add_argument_group("LEVEL OF DETAILS", "Level-of-detail (LOD) options.")
+    group.add_argument('--lod', dest='lod', action="store_true", default=False, help='If specified, create "level of detail" (lod) hal files and will put the lod.txt at the bigUrl instead of the original hal file. ')
+    group.add_argument('--lodTxtFile', dest='lodtxtfile', help='"hal Level of detail" lod text file. If specified, will put this at the bigUrl instead of the hal file. ')
+    group.add_argument('--lodDir', dest='loddir', help='"hal Level of detail" lod dir. If specified, will put this at the bigUrl instead of the hal file. ')
+    group.add_argument('--lodMaxBlock', dest='lodMaxBlock', type=int, help='Maximum number of blocks to display in a hal level of detail (see halLodInterpolate.py --help for the default value).', default=None)
+    group.add_argument('--lodScale', dest='lodScale', type=float, help='Scaling factor between two successive levels of detail (see halLodInterpolate.py --help for the default value).', default=None)
+    group.add_argument('--lodMaxDNA', dest='lodMaxDNA', type=int, help='Maximum query length such that its hal level of detail will contain nucleotide information.  (see halLodInterpolate.py --help for the default value).', default=None)
+    group.add_argument('--lodInMemory', dest='lodInMemory', action='store_true', help='Load entire hal file into memory when generating levels of detail instead of using hdf5 cache. Could result in drastic speedup. .', default=False)
+    group.add_argument('--lodMinSeqFrac', dest='lodMinSeqFrac', type=float, help='Minumum sequence length to sample as fraction of step size for level of detail generation: ie sequences with length <= floor(minSeqFrac * step) are ignored (see halLodExtract --help for default value).', default=None)
+    group.add_argument('--lodMinCovFrac', dest='lodMinCovFrac', type=float, help='Minimum fraction of a genome that must be covered by sequences that exceed --minSeqFrac * step.  LODs that would violate this threshold will not be generated (or displayed in  the browser).  This is seen a better than the alternative, which is to produce unreasonably sparse LODs because half the sequences were not sampled (see halLodInterpolate.py --help for default value).', default=None)
+    group.add_argument('--lodChunk', dest='lodChunk', type=int, help='HDF5 chunk size for generated levels of detail (see halLodExtract --help for default value).', default=None)
+    #group.add_argument('--snpwidth', dest='snpwidth', type=int, default=5000, help='Maximum window size to display SNPs. ')
+    group = parser.add_argument_group(group)
 

--- a/assemblyHub/rmskTrack.py
+++ b/assemblyHub/rmskTrack.py
@@ -43,10 +43,10 @@ def writeTrackDb_rmsk(f, rmskdir, genomedir):
     f.write("\n")
 
 def addRmskOptions(parser):
-    #group = OptionGroup(parser, "REPEATMASKER", "RepeatMasker options.")
-    group = OptionGroup(parser, "REPEATMASKER")
-    group.add_option('--rmskDir', dest='rmskdir', help="Directory containing repeatMasker's output files for each genome. Format: rmskDir/ then genome1/ then genome.rmsk.SINE.bb, genome.rmsk.LINE.bb, ... Default=%default")
-    parser.add_option_group(group)
+    #group = parser.add_argument_group("REPEATMASKER", "RepeatMasker options.")
+    group = parser.add_argument_group("REPEATMASKER")
+    group.add_argument('--rmskDir', dest='rmskdir', help="Directory containing repeatMasker's output files for each genome. Format: rmskDir/ then genome1/ then genome.rmsk.SINE.bb, genome.rmsk.LINE.bb, ... ")
+    group = parser.add_argument_group(group)
 
 def checkRmskOptions(parser, options):
     if options.rmskdir:

--- a/assemblyHub/snakeTrack.py
+++ b/assemblyHub/snakeTrack.py
@@ -11,11 +11,11 @@ from optparse import OptionGroup
 import re
 
 def addSnakeOptions(parser):
-    group = OptionGroup(parser, "SNAKE TRACKS", "Snake track options")
-    group.add_option('--selfAlignmentSnakes', dest="selfAlignmentTrack",
+    group = parser.add_argument_group("SNAKE TRACKS", "Snake track options")
+    group.add_argument('--selfAlignmentSnakes', dest="selfAlignmentTrack",
                      help="Produce a self-alignment snake track for every genome",
                      action="store_true", default=False)
-    parser.add_option_group(group)
+    group = parser.add_argument_group(group)
 
 def writeTrackDb_snakes(f, halfile, genomes, subgenomes, currgenome, properName, snpwidth=None, doSelfAlignment=False):
     for i, genome in enumerate(genomes):

--- a/assemblyHub/treeCommon.py
+++ b/assemblyHub/treeCommon.py
@@ -140,7 +140,7 @@ def getNeighbors(tree, name):
             neighbors.append(n)
     if currindex < len(sortedNames):
         middleindex = (len(sortedNames) + currindex)/2
-        neighbors.append(sortedNames[middleindex])
+        neighbors.append(sortedNames[int(middleindex)])
     return neighbors
 
 

--- a/lod/Makefile
+++ b/lod/Makefile
@@ -10,7 +10,8 @@ halLodExtract_objs = ${halLodExtract_srcs:%.cpp=${modObjDir}/%.o}
 srcs = ${libHalLod_srcs} ${halLodExtract_srcs}
 objs = ${srcs:%.cpp=${modObjDir}/%.o}
 depends = ${srcs:%.cpp=%.depend}
-progs = ${binDir}/halLodExtract
+pyprogs = ${binDir}/halLodInterpolate.py
+progs = ${binDir}/halLodExtract ${pyprogs}
 otherLibs = ${libHalLod}
 
 all : libs progs
@@ -20,6 +21,11 @@ progs: ${progs}
 clean : 
 	rm -f ${libHalLod} ${objs} ${progs} ${depends}
 test:
+
+${binDir}/%.py: %.py
+	@mkdir -p $(dir $@)
+	cp -f $< $@
+	chmod +x,-w $@
 
 include ${rootDir}/rules.mk
 

--- a/lod/halLodInterpolate.py
+++ b/lod/halLodInterpolate.py
@@ -167,7 +167,7 @@ def createLods(halPath, outLodPath, outDir, maxBlock, scale, overwrite,
         
         lodFile.write("%d %s\n" % (maxQueryLength, lodPath))
 
-        if prevStep > steps[-1]:
+        if prevStep is not None and prevStep > steps[-1]:
             break
         prevStep = step
         curStepFactor *= scaleCorFac

--- a/maf/hal2mafMP.py
+++ b/maf/hal2mafMP.py
@@ -328,6 +328,8 @@ def main(argv=None):
                                "incompatible with --length option")
     if args.sliceSize is not None and args.smallSize >= args.sliceSize:
         raise RuntimeError("--smallSize must be less than --sliceSize")
+    if not (args.splitBySequence or args.refTargets or args.refSequence):
+        raise RuntimeError("--splitBySequence, --refTargets or --refSequence required")
 
     # make a little id tag for temporary maf slices
     S = string.ascii_uppercase + string.digits

--- a/stats/halStats.py
+++ b/stats/halStats.py
@@ -40,7 +40,7 @@ def runParallelShellCommands(cmdList, numProc):
         # specifying a timeout allows keyboard interrupts to work?!
         # http://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
         try:
-            result.get(sys.maxsize)
+            result.get(20000000)
         except KeyboardInterrupt:
             mpPool.terminate()
             raise RuntimeError("Keyboard interrupt")

--- a/stats/halStats.py
+++ b/stats/halStats.py
@@ -17,7 +17,7 @@ from multiprocessing import Pool
 
 
 
-def runShellCommand(command):
+def runShellCommand(command, ascii=True):
     try:
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
                                    stderr=sys.stderr, bufsize=-1)
@@ -26,7 +26,7 @@ def runShellCommand(command):
         if sts != 0:
             raise RuntimeError("Command: %s exited with non-zero status %i" %
                                (command, sts))
-        return output
+        return output.decode() if ascii else output
     except KeyboardInterrupt:
         raise RuntimeError("Aborting %s" % command)
 


### PR DESCRIPTION
Some (most?) python scripts in HAL seem to no longer work (#108, #109).  On the surface, it seems due recent changes to move everything to Python 3, but it could be that things got broken in the hal binaries themselves which stopped the scripts from working. 

This PR is a quick stab at fixing some of the Python 3 issues in hal2assemblyHub.py and hal2mafMP.py.  

An alternative is to try rolling back versions, via this Cactus release https://github.com/ComparativeGenomicsToolkit/cactus/releases/tag/python2-version-2020-02-26
