### PR TITLE
added in ability to have extra, non-standard columns for BED type < 12

### DIFF
--- a/extract/impl/hal4dExtract.cpp
+++ b/extract/impl/hal4dExtract.cpp
@@ -31,7 +31,7 @@ void Extract4d::visitLine() {
     _outBedLines.clear();
     _refSequence = _refGenome->getSequence(_bedLine._chrName);
     if (_refSequence != NULL) {
-        if (_bedLine._version <= 9) {
+        if (_bedLine._bedType <= 9) {
             throw hal_exception("Only compatible with BED12 input. 4d sites are sensitive to frame."
                                 " Even if your genes are all single-exon, please convert them "
                                 "to BED12 first.");

--- a/liftover/Makefile
+++ b/liftover/Makefile
@@ -30,7 +30,8 @@ clean:
 	rm -rf ${libHalLiftover} ${objs} ${progs} ${depends} output
 
 test: unitTests halLiftoverBed12Test halLiftoverPsl12Test \
-	 halLiftoverBed3Test halLiftoverPsl3Test
+	halLiftoverBed3Test halLiftoverPsl3Test \
+	halLiftoverBed12ExtraTest halLiftoverBed4ExtraTest
 
 unitTests:
 	${binDir}/halLiftoverTests 
@@ -50,6 +51,16 @@ halLiftoverBed3Test: output/small.hdf5.hal
 halLiftoverPsl3Test: output/small.hdf5.hal
 	${binDir}/halLiftover --outPSL output/small.hdf5.hal Genome_0 tests/input/test1.bed3 Genome_2 output/$@.psl
 	diff -u tests/expected/$@.psl output/$@.psl
+
+# extra columns after 12
+halLiftoverBed12ExtraTest: output/small.hdf5.hal
+	${binDir}/halLiftover output/small.hdf5.hal Genome_0 tests/input/test1.bed12+2 Genome_2 output/$@.bed
+	diff -u tests/expected/$@.bed output/$@.bed
+
+# extra columns after 4
+halLiftoverBed4ExtraTest: output/small.hdf5.hal
+	${binDir}/halLiftover --bedType 4 output/small.hdf5.hal Genome_0 tests/input/test1.bed4+2 Genome_2 output/$@.bed
+	diff -u tests/expected/$@.bed output/$@.bed
 
 output/small.hdf5.hal: ../bin/halRandGen
 	@mkdir -p output

--- a/liftover/impl/halBedScanner.cpp
+++ b/liftover/impl/halBedScanner.cpp
@@ -22,11 +22,11 @@ BedScanner::BedScanner() : _bedStream(NULL) {
 BedScanner::~BedScanner() {
 }
 
-void BedScanner::scan(const string &bedPath) {
+void BedScanner::scan(const string &bedPath, int bedType) {
     assert(_bedStream == NULL);
     _bedStream = new ifstream(bedPath.c_str());
     try {
-        scan(_bedStream);
+        scan(_bedStream, bedType);
     } catch (hal_exception &e) {
         delete _bedStream;
         _bedStream = NULL;
@@ -37,7 +37,7 @@ void BedScanner::scan(const string &bedPath) {
     _bedStream = NULL;
 }
 
-void BedScanner::scan(istream *is) {
+void BedScanner::scan(istream *is, int bedType) {
     visitBegin();
     _bedStream = is;
     if (_bedStream->bad()) {
@@ -49,7 +49,7 @@ void BedScanner::scan(istream *is) {
         skipWhiteSpaces(_bedStream);
         while (_bedStream->good()) {
             ++_lineNumber;
-            _bedLine.read(*_bedStream, lineBuffer);
+            _bedLine.read(*_bedStream, lineBuffer, bedType);
             visitLine();
             skipWhiteSpaces(_bedStream);
         }

--- a/liftover/impl/halLiftoverMain.cpp
+++ b/liftover/impl/halLiftoverMain.cpp
@@ -36,7 +36,10 @@ static void initParser(CLParser &optionsParser) {
     optionsParser.addOptionFlag("outPSLWithName", "write output as input BED name followed by PSL line instead of "
                                                   "bed format",
                                 false);
-    optionsParser.setDescription("Map BED genome interval coordinates between "
+    optionsParser.addOption("bedType", "number of standard columns (3 to 12), columns beyond this are passed "
+                            "through.  This only needs to be specified for BEDs with less than 12 columns and "
+                            "having non-standard extra columns.", 0);
+    optionsParser.setDescription("Map BED or PSL genome interval coordinates between "
                                  "two genomes.");
 }
 
@@ -52,6 +55,7 @@ int main(int argc, char **argv) {
     string coalescenceLimitName;
     bool noDupes;
     bool append;
+    int bedType;
     bool outPSL;
     bool outPSLWithName;
     try {
@@ -64,6 +68,14 @@ int main(int argc, char **argv) {
         coalescenceLimitName = optionsParser.getOption<string>("coalescenceLimit");
         noDupes = optionsParser.getFlag("noDupes");
         append = optionsParser.getFlag("append");
+        if (optionsParser.specifiedOption("bedType")) {
+            bedType = optionsParser.getOption<int>("bedType");
+            if ((bedType < 3) or (bedType > 12)) {
+                throw hal_exception("--bedType must be between 3 and 12");
+            }
+        } else {
+            bedType = 0;
+        }
         outPSL = optionsParser.getFlag("outPSL");
         outPSLWithName = optionsParser.getFlag("outPSLWithName");
     } catch (exception &e) {
@@ -124,7 +136,7 @@ int main(int argc, char **argv) {
         }
 
         BlockLiftover liftover;
-        liftover.convert(alignment.get(), srcGenome, srcBedPtr, tgtGenome, tgtBedPtr, false,
+        liftover.convert(alignment.get(), srcGenome, srcBedPtr, tgtGenome, tgtBedPtr, bedType,
                          !noDupes, outPSL, outPSLWithName, coalescenceLimit);
 
 

--- a/liftover/inc/halBedLine.h
+++ b/liftover/inc/halBedLine.h
@@ -50,7 +50,7 @@ namespace hal {
     struct BedLine {
         BedLine();
         virtual ~BedLine();
-        std::istream &read(std::istream &is, std::string &lineBuffer);
+        std::istream &read(std::istream &is, std::string &lineBuffer, int bedType);
         std::ostream &write(std::ostream &os);
         std::ostream &writePSL(std::ostream &os, bool prefixWithName = false);
         bool validatePSL() const;
@@ -69,7 +69,7 @@ namespace hal {
         hal_index_t _itemB;
         std::vector<BedBlock> _blocks;
         std::vector<std::string> _extra;
-        int _version;
+        int _bedType; // number of standard columns
 
         // not part of output, but needed to preserve ordering
         hal_index_t _srcStart;

--- a/liftover/inc/halBedScanner.h
+++ b/liftover/inc/halBedScanner.h
@@ -24,8 +24,8 @@ namespace hal {
       public:
         BedScanner();
         virtual ~BedScanner();
-        virtual void scan(const std::string &bedPath);
-        virtual void scan(std::istream *bedStream);
+        virtual void scan(const std::string &bedPath, int bedType=0);
+        virtual void scan(std::istream *bedStream, int bedType=0);
 
         static size_t getNumColumns(const std::string &bedLine);
 

--- a/liftover/inc/halLiftover.h
+++ b/liftover/inc/halLiftover.h
@@ -23,7 +23,7 @@ namespace hal {
         virtual ~Liftover();
 
         void convert(const Alignment *alignment, const Genome *srcGenome, std::istream *inputFile, const Genome *tgtGenome,
-                     std::ostream *outputFile, bool addExtraColumns = false,
+                     std::ostream *outputFile, int bedType = 0,
                      bool traverseDupes = true, bool outPSL = false, bool outPSLWithName = false,
                      const Genome *coalescenceLimit = NULL);
 
@@ -46,7 +46,7 @@ namespace hal {
       protected:
         AlignmentConstPtr _alignment;
         std::ostream *_outBedStream;
-        bool _addExtraColumns;
+        bool _bedType;
         bool _traverseDupes;
         BedList _outBedLines;
         bool _outPSL;

--- a/liftover/tests/expected/halLiftoverBed12ExtraTest.bed
+++ b/liftover/tests/expected/halLiftoverBed12ExtraTest.bed
@@ -1,0 +1,1 @@
+Genome_2_seq	0	128	region1	100	+	0	128	0,0,0	1	128	0	Fred	Betty

--- a/liftover/tests/expected/halLiftoverBed4ExtraTest.bed
+++ b/liftover/tests/expected/halLiftoverBed4ExtraTest.bed
@@ -1,0 +1,1 @@
+Genome_2_seq	0	128	region1	Fred	Wilma

--- a/liftover/tests/halLiftoverTests.cpp
+++ b/liftover/tests/halLiftoverTests.cpp
@@ -261,7 +261,7 @@ void BedLiftoverTest::liftAndCheck(const Alignment *alignment,
     stringstream bedFile(inBed);
     stringstream outStream;
     liftover.convert(alignment, srcGenome, &bedFile, tgtGenome, &outStream,
-                     false, true, outPSL, outPSLWithName);
+                     0, true, outPSL, outPSLWithName);
     if (outStream.str() != expectBed) {
         cerr << "Got: " << endl << outStream.str() << endl;
         cerr << "Expected: " << endl << expectBed << endl;

--- a/liftover/tests/input/test1.bed12+2
+++ b/liftover/tests/input/test1.bed12+2
@@ -1,0 +1,1 @@
+Genome_0_seq	0	128	region1	100	+	0	128	0,0,0	1	128,	0,	Fred	Betty

--- a/liftover/tests/input/test1.bed4+2
+++ b/liftover/tests/input/test1.bed4+2
@@ -1,0 +1,1 @@
+Genome_0_seq	0	128	region1	Fred	Wilma

--- a/maf/impl/halMafBed.cpp
+++ b/maf/impl/halMafBed.cpp
@@ -28,7 +28,7 @@ void MafBed::visitLine() {
              << _refGenome->getName() << '\n';
         return;
     }
-    if (_bedLine._version <= 9) {
+    if (_bedLine._bedType <= 9) {
         if (_bedLine._end <= _bedLine._start || _bedLine._end > (hal_index_t)refSequence->getSequenceLength()) {
             cerr << "Line " << _lineNumber << ": BED coordinates invalid\n";
         } else {

--- a/synteny/impl/hal2psl.cpp
+++ b/synteny/impl/hal2psl.cpp
@@ -13,9 +13,7 @@ void Hal2Psl::storePslResults(std::vector<PslBlock> &pslBlocks) {
 
     BedList::iterator i = _outBedLines.begin();
     for (; i != _outBedLines.end(); ++i) {
-        if (_addExtraColumns == false) {
-            i->_extra.clear();
-        }
+        i->_extra.clear();  // not valid in PSLs
         makeUpPsl(i->_psl, i->_blocks, i->_strand, i->_start, i->_chrName, pslBlocks);
     }
 }
@@ -28,7 +26,6 @@ std::vector<PslBlock> Hal2Psl::convert2psl(const Alignment *alignment, const Gen
         _tgtGenome = tgtGenome;
         _coalescenceLimit = NULL;
         _traverseDupes = true;
-        _addExtraColumns = false;
         _missedSet.clear();
         _tgtSet.clear();
         _tgtSet.insert(tgtGenome);


### PR DESCRIPTION
added in ability to have extra, non-standard columns for BED type < 12
added tests
change terminology to match that used by browser (BED type)

fixes #121 