### PR TITLE
update hal2mafMP.py to support --hdf5InMemory

### DIFF
--- a/maf/hal2mafMP.py
+++ b/maf/hal2mafMP.py
@@ -30,7 +30,7 @@ def getHal2MafCmd(options):
     for opt, val in list(options.__dict__.items()):
         if (val is not None and
             ((not isinstance(val, bool) or (val == True)) and
-             (opt in ('cacheMDC', 'cacheRDC', 'cacheW0', 'cacheBytes', 'inMemory', 'refGenome',
+             (opt in ('cacheMDC', 'cacheRDC', 'cacheW0', 'cacheBytes', 'hdf5InMemory', 'refGenome',
                       'refSequence', 'refTargets', 'start', 'length', 'rootGenome',
                       'targetGenomes', 'maxRefGap', 'noDupes', 'noAncestors', 'onlySequenceNames')))):
             if val is not True:
@@ -248,7 +248,7 @@ def main():
     hdf5Grp.add_argument("--cacheW0",
                          help="w0 parameter fro hdf5 cache", type=float,
                          default=None)
-    hdf5Grp.add_argument("--inMemory",
+    hdf5Grp.add_argument("--hdf5InMemory",
                          help="load all data in memory (& disable hdf5 cache)",
                          action="store_true",
                          default=False)


### PR DESCRIPTION
hal2maf deprecated the option '--inMemory'.  In order for hal2mafMP.py to support this change  "inMemory" needs to be updated to "hdf5InMemory".  