### PR TITLE
Make installed python scripts executable by all users

### DIFF
--- a/analysis/Makefile
+++ b/analysis/Makefile
@@ -14,7 +14,7 @@ test:
 ${binDir}/%.py : neutralIndel/%.py
 	@mkdir -p $(dir $@)
 	cp -f $< $@
-	chmod u+x,a-w $@
+	chmod a+x,a-w $@
 
 # Local Variables:
 # mode: makefile-gmake

--- a/lod/Makefile
+++ b/lod/Makefile
@@ -25,7 +25,7 @@ test:
 ${binDir}/%.py: %.py
 	@mkdir -p $(dir $@)
 	cp -f $< $@
-	chmod +x,-w $@
+	chmod a+x,-w $@
 
 include ${rootDir}/rules.mk
 

--- a/maf/Makefile
+++ b/maf/Makefile
@@ -84,7 +84,7 @@ output/small.hdf5.hal:
 ${binDir}/%.py: %.py
 	@mkdir -p $(dir $@)
 	cp -f $< $@
-	chmod +x,-w $@
+	chmod a+x,-w $@
 
 flake8:
 	${PYTHON} -m flake8 *.py

--- a/rules.mk
+++ b/rules.mk
@@ -8,7 +8,7 @@
 ${binDir}/%.py : %.py
 	@mkdir -p $(dir $@)
 	cp -f $< $@
-	chmod u+x,a-w $@
+	chmod a+x,a-w $@
 
 # Generate .depend and compile objects. Due to some test code is being
 # compiled by different modules, it is possible to generate the .depend file


### PR DESCRIPTION
Some of the Python scripts that are installed by HAL currently lack the execute bit. While rules.mk causes these to be installed with the user execute bit set, this will only allow the user that installed HAL to execute these scripts. Either the `chmod` command in rules.mk can be altered to set the execute bit on installed python scripts for all users (as suggested by this PR), or the execute bit can be set on the python scripts in the git repo (or both).