### PR TITLE
Need Python 3 integer division operator in halPhyloPMP.py

### DIFF
--- a/phyloP/halPhyloPMP.py
+++ b/phyloP/halPhyloPMP.py
@@ -86,11 +86,11 @@ def computeSlices(options, seqLen):
         if options.sliceSize is None or options.sliceSize >= inLength:
             yield (inStart, inLength, None)
         else:
-            for i in range(inLength / options.sliceSize):
+            for i in range(inLength // options.sliceSize):
                 yield (inStart + i * options.sliceSize, options.sliceSize, i)
             r = inLength % options.sliceSize
             if r > 0:
-                i = inLength / options.sliceSize
+                i = inLength // options.sliceSize
                 yield (inStart + i * options.sliceSize, r, i)
 
 def concatenateSlices(sliceOpts, sliceCmds):


### PR DESCRIPTION
A user reported the following error:
```
Traceback (most recent call last):
  File "/usr/local/bin/halPhyloPMP.py", line 306, in <module>
    sys.exit(main())
  File "/usr/local/bin/halPhyloPMP.py", line 303, in main
    runParallelSlices(args)
  File "/usr/local/bin/halPhyloPMP.py", line 158, in runParallelSlices
    for sStart, sLen, sIdx in computeSlices(seqOpts, totalLength):
  File "/usr/local/bin/halPhyloPMP.py", line 89, in computeSlices
    for i in range(inLength / options.sliceSize):
TypeError: 'float' object cannot be interpreted as an integer
```
It looks like the requirement for integer division here was missed in the Python 2 -> 3 translation