### PR TITLE
Fix formatting on the CXX_ABI_DEF environment flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ From the parent directory of where you want HAL installed:
     If you are using older version of HDF5, such as installed on Centos,
     you may need to set 
     
-    `export CXX_ABI_DEF='-D_GLIBCXX_USE_CXX11_ABI=1'
+    `export CXX_ABI_DEF=-D_GLIBCXX_USE_CXX11_ABI=1`
     
     If you get undefined functions base on string type with errors about
     `std::__cxx11::basic_string` vs `std::basic_string`.


### PR DESCRIPTION
The previous formatting was inconsistent with the rest of the formatting and can ( and did ) lead to strange g++ compiling errors in sonLib specifically this 
https://github.com/ComparativeGenomicsToolkit/sonLib/issues/9