### PR TITLE
Revert back to alignment smart pointers in hal tools

### DIFF
--- a/api/tests/halAlignmentTreesTest.cpp
+++ b/api/tests/halAlignmentTreesTest.cpp
@@ -21,7 +21,7 @@ using namespace hal;
 
 class AlignmentTestTrees : public AlignmentTest {
   public:
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -37,7 +37,7 @@ class AlignmentTestTrees : public AlignmentTest {
         alignment->updateBranchLength("Root", "Leaf2", 5.1);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         CuAssertTrue(_testCase, alignment->getRootName() == "NewRoot");
         CuAssertTrue(_testCase,
                      alignment->getNewickTree() == "((Leaf:10,Leaf1:3,Leaf2:5.1,Leaf3:6.1,Leaf4:7.1)Root:15)NewRoot;");

--- a/api/tests/halApiTestSupport.cpp
+++ b/api/tests/halApiTestSupport.cpp
@@ -21,15 +21,15 @@ using namespace hal;
  */
 static string storageDriverToTest;
 
-Alignment *getTestAlignmentInstances(const std::string &storageFormat, const std::string &alignmentPath, unsigned mode) {
+AlignmentPtr getTestAlignmentInstances(const std::string &storageFormat, const std::string &alignmentPath, unsigned mode) {
     if (storageFormat == STORAGE_FORMAT_HDF5) {
-        return hdf5AlignmentInstance(alignmentPath, mode, hdf5DefaultFileCreatPropList(), hdf5DefaultFileAccPropList(),
-                                     hdf5DefaultDSetCreatPropList());
+        return AlignmentPtr(hdf5AlignmentInstance(alignmentPath, mode, hdf5DefaultFileCreatPropList(), hdf5DefaultFileAccPropList(),
+                                                  hdf5DefaultDSetCreatPropList()));
 
     } else if (storageFormat == hal::STORAGE_FORMAT_MMAP) {
         // We use a default init size of only 1GiB here, because the test
         // alignments we create are relatively small.
-        return mmapAlignmentInstance(alignmentPath, mode, 1024 * 1024 * 1024);
+        return AlignmentPtr(mmapAlignmentInstance(alignmentPath, mode, 1024 * 1024 * 1024));
     } else {
         throw hal_exception("invalid storage format: " + storageFormat);
     }
@@ -127,13 +127,13 @@ void AlignmentTest::checkOne(CuTest *testCase, const string &storageFormat) {
     // test with created
     AlignmentPtr calignment(getTestAlignmentInstances(storageFormat, alignmentPath, CREATE_ACCESS));
     _createPath = alignmentPath;
-    createCallBack(calignment.get());
+    createCallBack(calignment);
     calignment->close();
 
     // test with existing alignment
     AlignmentPtr ralignment(getTestAlignmentInstances(storageFormat, alignmentPath, READ_ACCESS));
     _checkPath = alignmentPath;
-    checkCallBack(ralignment.get());
+    checkCallBack(ralignment);
     ralignment->close();
 
     ::unlink(alignmentPath.c_str());

--- a/api/tests/halApiTestSupport.h
+++ b/api/tests/halApiTestSupport.h
@@ -18,7 +18,7 @@ extern "C" {
 using namespace hal;
 using namespace std;
 
-Alignment *getTestAlignmentInstances(const string &storageFormat, const string &alignmentPath, unsigned mode);
+AlignmentPtr getTestAlignmentInstances(const string &storageFormat, const string &alignmentPath, unsigned mode);
 
 /** parse command line and run a test suite for the given storage driver,
  * return exit code  */
@@ -33,9 +33,9 @@ class AlignmentTest {
     virtual ~AlignmentTest() {
     }
     void check(CuTest *testCase);
-    virtual void createCallBack(Alignment *alignment) {
+    virtual void createCallBack(AlignmentPtr alignment) {
     }
-    virtual void checkCallBack(const Alignment *alignment) {
+    virtual void checkCallBack(AlignmentConstPtr alignment) {
     }
     CuTest *_testCase;
     string _createPath;

--- a/api/tests/halBottomSegmentTest.cpp
+++ b/api/tests/halBottomSegmentTest.cpp
@@ -18,7 +18,7 @@ using namespace hal;
 struct BottomSegmentSimpleIteratorTest : public AlignmentTest {
     std::vector<BottomSegmentStruct> _bottomSegments;
 
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *ancGenome = alignment->addRootGenome("Anc0", 0);
         size_t numChildren = 9;
         for (size_t i = 0; i < numChildren; ++i) {
@@ -48,7 +48,7 @@ struct BottomSegmentSimpleIteratorTest : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("Anc0");
         CuAssertTrue(_testCase, ancGenome->getNumBottomSegments() == _bottomSegments.size());
         BottomSegmentIteratorPtr bsIt = ancGenome->getBottomSegmentIterator(0);
@@ -103,7 +103,7 @@ struct BottomSegmentSequenceTest : public AlignmentTest {
     std::vector<BottomSegmentStruct> _bottomSegments;
     std::vector<std::string> _sequences;
 
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *ancGenome = alignment->addRootGenome("Anc0", 0);
         vector<Sequence::Info> seqVec(1);
         seqVec[0] = Sequence::Info("Sequence", 1000000, 5000, 700000);
@@ -114,7 +114,7 @@ struct BottomSegmentSequenceTest : public AlignmentTest {
         bsIt->getBottomSegment()->setCoordinates(500, 9);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("Anc0");
         BottomSegmentIteratorPtr bsIt = ancGenome->getBottomSegmentIterator(100);
         CuAssertTrue(_testCase, bsIt->getBottomSegment()->getStartPosition() == 500);
@@ -130,7 +130,7 @@ struct BottomSegmentSequenceTest : public AlignmentTest {
 
 struct BottomSegmentIteratorParseTest : public AlignmentTest {
 
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         vector<Sequence::Info> seqVec(1);
 
         BottomSegmentIteratorPtr bi;
@@ -206,7 +206,7 @@ struct BottomSegmentIteratorParseTest : public AlignmentTest {
         bs.applyTo(bi);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi;
         TopSegmentIteratorPtr ti;
 
@@ -256,7 +256,7 @@ struct BottomSegmentIteratorParseTest : public AlignmentTest {
 };
 
 struct BottomSegmentIteratorToSiteTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         vector<Sequence::Info> seqVec(1);
 
         BottomSegmentIteratorPtr bi;
@@ -308,7 +308,7 @@ struct BottomSegmentIteratorToSiteTest : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi;
 
         // case 1
@@ -323,7 +323,7 @@ struct BottomSegmentIteratorToSiteTest : public AlignmentTest {
 
 struct BottomSegmentIteratorReverseTest : public AlignmentTest {
 
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         vector<Sequence::Info> seqVec(1);
 
         BottomSegmentIteratorPtr bi;
@@ -360,7 +360,7 @@ struct BottomSegmentIteratorReverseTest : public AlignmentTest {
         ts.applyTo(ti);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi, bi2;
         TopSegmentIteratorPtr ti;
 
@@ -422,7 +422,7 @@ struct BottomSegmentIteratorReverseTest : public AlignmentTest {
 };
 
 struct BottomSegmentIsGapTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         size_t numSequences = 3;
         vector<Sequence::Info> seqVec(numSequences);
 
@@ -480,7 +480,7 @@ struct BottomSegmentIsGapTest : public AlignmentTest {
         ti->getTopSegment()->setParentIndex(NULL_INDEX);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi;
         TopSegmentIteratorPtr ti;
 

--- a/api/tests/halColumnIteratorTest.cpp
+++ b/api/tests/halColumnIteratorTest.cpp
@@ -22,12 +22,12 @@ using namespace hal;
 static RandNumberGen rng;
 
 struct ColumnIteratorBaseTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         createRandomAlignment(rng, alignment, 10, 1e-10, 2, 3, 77, 77, 10, 10);
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *genome = alignment->openGenome(alignment->getRootName());
         const Sequence *sequence = genome->getSequenceBySite(0);
         assert(genome != NULL);
@@ -53,7 +53,7 @@ struct ColumnIteratorBaseTest : public AlignmentTest {
 };
 
 struct ColumnIteratorDepthTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         double branchLength = 1e-10;
 
         alignment->addRootGenome("grandpa");
@@ -142,8 +142,8 @@ struct ColumnIteratorDepthTest : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *genome = alignment->openGenome("grandpa");
         checkGenome(genome);
         genome = alignment->openGenome("dad");
@@ -156,7 +156,7 @@ struct ColumnIteratorDepthTest : public AlignmentTest {
 };
 
 struct ColumnIteratorDupTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         double branchLength = 1e-10;
 
         alignment->addRootGenome("dad");
@@ -268,8 +268,8 @@ struct ColumnIteratorDupTest : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *genome = alignment->openGenome("dad");
         checkGenome(genome);
         genome = alignment->openGenome("son1");
@@ -280,7 +280,7 @@ struct ColumnIteratorDupTest : public AlignmentTest {
 };
 
 struct ColumnIteratorInvTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         double branchLength = 1e-10;
 
         alignment->addRootGenome("grandpa");
@@ -449,15 +449,15 @@ struct ColumnIteratorInvTest : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *genome = alignment->openGenome("son1");
         checkGenome(genome);
     }
 };
 
 struct ColumnIteratorGapTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         double branchLength = 1e-10;
 
         alignment->addRootGenome("grandpa");
@@ -509,8 +509,8 @@ struct ColumnIteratorGapTest : public AlignmentTest {
         dad->setString("ACGTGGGG");
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *dad = alignment->openGenome("dad");
         const Sequence *dadSeq = dad->getSequence("dseq");
         const Genome *grandpa = alignment->openGenome("grandpa");
@@ -540,7 +540,7 @@ struct ColumnIteratorGapTest : public AlignmentTest {
 };
 
 struct ColumnIteratorMultiGapTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         double branchLength = 1e-10;
 
         alignment->addRootGenome("adam");
@@ -635,8 +635,8 @@ struct ColumnIteratorMultiGapTest : public AlignmentTest {
         dad->setString("ACGTGGGG");
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
 
         const Genome *dad = alignment->openGenome("dad");
         const Sequence *dadSeq = dad->getSequence("dseq");
@@ -735,7 +735,7 @@ struct ColumnIteratorMultiGapTest : public AlignmentTest {
 };
 
 struct ColumnIteratorMultiGapInvTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         double branchLength = 1e-10;
 
         alignment->addRootGenome("adam");
@@ -837,8 +837,8 @@ struct ColumnIteratorMultiGapInvTest : public AlignmentTest {
         dad->setString("ACGTGGGG");
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *dad = alignment->openGenome("dad");
         const Sequence *dadSeq = dad->getSequence("dseq");
         const Genome *grandpa = alignment->openGenome("grandpa");
@@ -932,11 +932,11 @@ struct ColumnIteratorMultiGapInvTest : public AlignmentTest {
 };
 
 struct ColumnIteratorPositionCacheTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         alignment->addRootGenome("foobar");
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         size_t trials = 10;
         size_t sizes[] = {10, 100, 1000, 2000, 3000, 4000, 5000, 6000, 10000, 1000000};
         size_t entries = 10000;

--- a/api/tests/halGappedSegmentIteratorTest.cpp
+++ b/api/tests/halGappedSegmentIteratorTest.cpp
@@ -15,7 +15,7 @@ using namespace std;
 using namespace hal;
 
 struct GappedSegmentSimpleIteratorTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         addIdenticalParentChild(alignment, 2, 100, 5);
         Genome *parent = alignment->openGenome(alignment->getRootName());
         Genome *child = parent->getChild(0);
@@ -32,7 +32,7 @@ struct GappedSegmentSimpleIteratorTest : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *child = alignment->openGenome("child");
         const Genome *parent = alignment->openGenome("parent");
 
@@ -101,7 +101,7 @@ struct GappedSegmentSimpleIteratorTest : public AlignmentTest {
 };
 
 struct GappedSegmentSimpleIteratorTest2 : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         addIdenticalParentChild(alignment, 2, 100, 5);
         Genome *parent = alignment->openGenome(alignment->getRootName());
         Genome *child = parent->getChild(0);
@@ -123,7 +123,7 @@ struct GappedSegmentSimpleIteratorTest2 : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *child = alignment->openGenome("child");
         const Genome *parent = alignment->openGenome("parent");
 
@@ -214,7 +214,7 @@ struct GappedSegmentSimpleIteratorTest2 : public AlignmentTest {
 };
 
 struct GappedSegmentIteratorIndelTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         addIdenticalParentChild(alignment, 1, 20, 5);
         Genome *parent = alignment->openGenome(alignment->getRootName());
         Genome *child = parent->getChild(0);
@@ -245,7 +245,7 @@ struct GappedSegmentIteratorIndelTest : public AlignmentTest {
                  }*/
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *child = alignment->openGenome("child");
         const Genome *parent = alignment->openGenome("parent");
 

--- a/api/tests/halGenomeTest.cpp
+++ b/api/tests/halGenomeTest.cpp
@@ -24,7 +24,7 @@ using namespace std;
 using namespace hal;
 
 struct GenomeMetaTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -34,7 +34,7 @@ struct GenomeMetaTest : public AlignmentTest {
         ancMeta->set("Young", "Jeezy");
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("AncGenome");
         const MetaData *ancMeta = ancGenome->getMetaData();
         CuAssertTrue(_testCase, ancMeta->get("Young") == "Jeezy");
@@ -47,7 +47,7 @@ struct GenomeMetaTest : public AlignmentTest {
 
 struct GenomeCreateTest : public AlignmentTest {
     std::string _string;
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -70,7 +70,7 @@ struct GenomeCreateTest : public AlignmentTest {
         leaf3Genome->setDimensions(seqVec);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *dudGenome = NULL;
         try {
             dudGenome = alignment->openGenome("Zebra");
@@ -103,7 +103,7 @@ struct GenomeCreateTest : public AlignmentTest {
 };
 
 struct GenomeUpdateTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -115,7 +115,7 @@ struct GenomeUpdateTest : public AlignmentTest {
         ancGenome->setDimensions(seqVec);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("AncGenome");
         CuAssertTrue(_testCase, ancGenome->getName() == "AncGenome");
         CuAssertTrue(_testCase, ancGenome->getSequenceLength() == 10000005);
@@ -126,7 +126,7 @@ struct GenomeUpdateTest : public AlignmentTest {
 
 struct GenomeStringTest : public AlignmentTest {
     std::string _string;
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
         hal_size_t seqLength = 28889943;
@@ -139,7 +139,7 @@ struct GenomeStringTest : public AlignmentTest {
         ancGenome->setString(_string);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("AncGenome");
         CuAssertTrue(_testCase, ancGenome->getName() == "AncGenome");
         string genomeString;
@@ -152,7 +152,7 @@ struct GenomeCopyTest : public AlignmentTest {
     std::string _path;
     AlignmentPtr _secondAlignment;
     
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -266,7 +266,7 @@ struct GenomeCopyTest : public AlignmentTest {
         _secondAlignment->close();
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         // FIXME: halAlignment->open() fails miserably but
         // openHalAlignmentReadOnly works? Probably some state isn't cleared
         // on close.
@@ -400,7 +400,7 @@ struct GenomeCopySegmentsWhenSequencesOutOfOrderTest : public AlignmentTest {
     // "Sequence1" positions, and "Sequence2" to "Sequence2", but try
     // copying the segments to an alignment with "Sequence2" before
     // "Sequence1" in the ordering.
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -507,7 +507,7 @@ struct GenomeCopySegmentsWhenSequencesOutOfOrderTest : public AlignmentTest {
     void checkTopSegments(Genome *genome, hal_size_t width, CuTest *testCase) {
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         // FIXME: halAlignment->open() fails miserably but
         // openHalAlignmentReadOnly works? Probably some state isn't cleared
         // on close.

--- a/api/tests/halMappedSegmentTest.cpp
+++ b/api/tests/halMappedSegmentTest.cpp
@@ -22,7 +22,7 @@ using namespace hal;
 static RandNumberGen rng;
 
 struct MappedSegmentMapUpTest : virtual public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         vector<Sequence::Info> seqVec(1);
 
         BottomSegmentIteratorPtr bi;
@@ -182,7 +182,7 @@ struct MappedSegmentMapUpTest : virtual public AlignmentTest {
         }
     }
 
-    void testTopSegment(const Alignment *alignment, TopSegmentIteratorPtr top, const string &ancName) {
+    void testTopSegment(AlignmentConstPtr alignment, TopSegmentIteratorPtr top, const string &ancName) {
         const Genome *parent = alignment->openGenome(ancName);
         MappedSegmentSet results;
         halMapSegmentSP(top, results, parent, NULL, false);
@@ -206,8 +206,8 @@ struct MappedSegmentMapUpTest : virtual public AlignmentTest {
         CuAssertTrue(_testCase, mseg->getReversed() == bottom->getReversed());
     }
 
-    virtual void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    virtual void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *child1 = alignment->openGenome("child1");
         const Genome *child2 = alignment->openGenome("child2");
         TopSegmentIteratorPtr top = child2->getTopSegmentIterator();
@@ -240,7 +240,7 @@ struct MappedSegmentMapUpTest : virtual public AlignmentTest {
 };
 
 struct MappedSegmentParseTest : virtual public MappedSegmentMapUpTest {
-    void testTopSegment(const Alignment *alignment, TopSegmentIteratorPtr top) {
+    void testTopSegment(AlignmentConstPtr alignment, TopSegmentIteratorPtr top) {
         const Genome *parent = alignment->openGenome("parent");
         MappedSegmentSet results;
         halMapSegmentSP(top, results, parent, NULL, false);
@@ -274,8 +274,8 @@ struct MappedSegmentParseTest : virtual public MappedSegmentMapUpTest {
         }
     }
 
-    virtual void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    virtual void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *g1 = alignment->openGenome("g1");
         const Genome *g2 = alignment->openGenome("g2");
         const Genome *g3 = alignment->openGenome("g3");
@@ -294,7 +294,7 @@ struct MappedSegmentParseTest : virtual public MappedSegmentMapUpTest {
 };
 
 struct MappedSegmentMapDownTest : public MappedSegmentMapUpTest {
-    void testBottomSegment(const Alignment *alignment, BottomSegmentIteratorPtr bottom,
+    void testBottomSegment(AlignmentConstPtr alignment, BottomSegmentIteratorPtr bottom,
                            hal_size_t childIndex) {
         const Genome *child = bottom->getGenome()->getChild(childIndex);
         MappedSegmentSet results;
@@ -313,8 +313,8 @@ struct MappedSegmentMapDownTest : public MappedSegmentMapUpTest {
         CuAssertTrue(_testCase, mseg->getReversed() == top->getReversed());
     }
 
-    virtual void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    virtual void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *parent = alignment->openGenome("parent");
 
         BottomSegmentIteratorPtr bottom = parent->getBottomSegmentIterator();
@@ -330,7 +330,7 @@ struct MappedSegmentMapDownTest : public MappedSegmentMapUpTest {
 };
 
 struct MappedSegmentMapAcrossTest : public MappedSegmentMapUpTest {
-    void testTopSegment(const Alignment *alignment, TopSegmentIteratorPtr top) {
+    void testTopSegment(AlignmentConstPtr alignment, TopSegmentIteratorPtr top) {
         const Genome *parent = top->getGenome()->getParent();
         const Genome *other =
             top->getGenome()->getName() == "child1" ? alignment->openGenome("child2") : alignment->openGenome("child1");
@@ -352,8 +352,8 @@ struct MappedSegmentMapAcrossTest : public MappedSegmentMapUpTest {
         CuAssertTrue(_testCase, mseg->getReversed() == sister->getReversed());
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *child1 = alignment->openGenome("child1");
         const Genome *child2 = alignment->openGenome("child2");
         TopSegmentIteratorPtr top = child2->getTopSegmentIterator();
@@ -372,7 +372,7 @@ struct MappedSegmentMapAcrossTest : public MappedSegmentMapUpTest {
 };
 
  struct MappedSegmentMapDupeTest : virtual public AlignmentTest {
-    virtual void createCallBack(Alignment *alignment) {
+    virtual void createCallBack(AlignmentPtr alignment) {
         vector<Sequence::Info> seqVec(1);
 
         BottomSegmentIteratorPtr bi;
@@ -423,8 +423,8 @@ struct MappedSegmentMapAcrossTest : public MappedSegmentMapUpTest {
         ts.applyTo(ti);
     }
 
-    virtual void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    virtual void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
         const Genome *parent = alignment->openGenome("parent");
         const Genome *child1 = alignment->openGenome("child1");
         const Genome *child2 = alignment->openGenome("child2");
@@ -476,7 +476,7 @@ struct MappedSegmentMapAcrossTest : public MappedSegmentMapUpTest {
 };
 
 struct MappedSegmentMapExtraParalogsTest : virtual public AlignmentTest {
-    virtual void createCallBack(Alignment *alignment) {
+    virtual void createCallBack(AlignmentPtr alignment) {
         vector<Sequence::Info> seqVec(1);
 
         BottomSegmentIteratorPtr bi;
@@ -563,8 +563,8 @@ struct MappedSegmentMapExtraParalogsTest : virtual public AlignmentTest {
         parent->fixParseInfo();
     }
 
-    virtual void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    virtual void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
 
         const Genome *grandChild1 = alignment->openGenome("grandChild1");
         const Genome *grandChild2 = alignment->openGenome("grandChild2");
@@ -618,12 +618,12 @@ struct MappedSegmentColCompareTest : virtual public AlignmentTest {
     const Genome *_ref;
     const Genome *_tgt;
 
-    virtual void checkCallBack(const Alignment *alignment) {
+    virtual void checkCallBack(AlignmentConstPtr alignment) {
         if (alignment->getNumGenomes() == 0) {
             return;
         }
 
-        validateAlignment(alignment);
+        validateAlignment(alignment.get());
         set<const Genome *> genomeSet;
         hal::getGenomesInSubTree(alignment->openGenome(alignment->getRootName()), genomeSet);
         for (set<const Genome *>::iterator i = genomeSet.begin(); i != genomeSet.end(); ++i) {
@@ -759,39 +759,39 @@ struct MappedSegmentColCompareTest : virtual public AlignmentTest {
 };
 
 struct MappedSegmentColCompareTestCheck1 : virtual public MappedSegmentMapUpTest, virtual public MappedSegmentColCompareTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         MappedSegmentMapUpTest::createCallBack(alignment);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         MappedSegmentColCompareTest::checkCallBack(alignment);
     }
 };
 
 struct MappedSegmentColCompareTestCheck2 : virtual public MappedSegmentMapDupeTest, virtual public MappedSegmentColCompareTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         MappedSegmentMapDupeTest::createCallBack(alignment);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         MappedSegmentColCompareTest::checkCallBack(alignment);
     }
 };
 
 struct MappedSegmentColCompareTest1 : public MappedSegmentColCompareTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         createRandomAlignment(rng, alignment, 2, 0.1, 2, 6, 10, 1000, 5, 10);
     }
 };
 
 struct MappedSegmentColCompareTest2 : public MappedSegmentColCompareTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         createRandomAlignment(rng, alignment, 1.25, 0.7, 2, 8, 2, 50, 10, 500);
     }
 };
 
 struct MappedSegmentColCompareTest3 : public MappedSegmentColCompareTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         createRandomAlignment(rng, alignment, 1.5, 0.7, 6, 12, 1, 100, 50, 1000);
     }
 };

--- a/api/tests/halMetaDataTest.cpp
+++ b/api/tests/halMetaDataTest.cpp
@@ -19,7 +19,7 @@ using namespace std;
 using namespace hal;
 
 struct MetaDataTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -40,7 +40,7 @@ struct MetaDataTest : public AlignmentTest {
         CuAssertTrue(_testCase, meta->getMap().size() == 3);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const MetaData *meta = alignment->getMetaData();
 
         CuAssertTrue(_testCase, meta->get("colour") == "black");

--- a/api/tests/halRandomData.cpp
+++ b/api/tests/halRandomData.cpp
@@ -41,7 +41,7 @@ static inline void mutateString(RandNumberGen &rng, string &buffer, double branc
     }
 }
 
-static void createRandomAlignmentGenome(RandNumberGen &rng, Alignment *newAlignment, deque<string> &genomeNameQueue) {
+static void createRandomAlignmentGenome(RandNumberGen &rng, AlignmentPtr newAlignment, deque<string> &genomeNameQueue) {
     Genome *genome = newAlignment->openGenome(genomeNameQueue.back());
     genomeNameQueue.pop_back();
 
@@ -59,7 +59,7 @@ static void createRandomAlignmentGenome(RandNumberGen &rng, Alignment *newAlignm
     newAlignment->closeGenome(genome);
 }
 
-void hal::createRandomAlignment(RandNumberGen &rng, Alignment *newAlignment, double meanDegree, double maxBranchLength,
+void hal::createRandomAlignment(RandNumberGen &rng, AlignmentPtr newAlignment, double meanDegree, double maxBranchLength,
                                 hal_size_t minGenomes, hal_size_t maxGenomes, hal_size_t minSegmentLength,
                                 hal_size_t maxSegmentLength, hal_size_t minSegments, hal_size_t maxSegments) {
     if (meanDegree <= 0.0) {
@@ -99,7 +99,7 @@ void hal::createRandomAlignment(RandNumberGen &rng, Alignment *newAlignment, dou
     }
 }
 
-static void createRandomTreeGenome(RandNumberGen &rng, Alignment *newAlignment, double meanDegree, double maxBranchLength,
+static void createRandomTreeGenome(RandNumberGen &rng, AlignmentPtr newAlignment, double meanDegree, double maxBranchLength,
                                    hal_size_t minGenomes, hal_size_t maxGenomes, size_t &genomeCount,
                                    deque<string> &genomeNameQueue) {
     Genome *genome = newAlignment->openGenome(genomeNameQueue.back());
@@ -119,7 +119,7 @@ static void createRandomTreeGenome(RandNumberGen &rng, Alignment *newAlignment, 
     }
 }
 
-void hal::createRandomTree(RandNumberGen &rng, Alignment *newAlignment, double meanDegree, double maxBranchLength,
+void hal::createRandomTree(RandNumberGen &rng, AlignmentPtr newAlignment, double meanDegree, double maxBranchLength,
                            hal_size_t minGenomes, hal_size_t maxGenomes) {
     assert(newAlignment->getNumGenomes() == 0);
 
@@ -149,7 +149,7 @@ static hal_size_t calcNumTopSegments(Genome *parent, hal_size_t length, hal_size
     return numTopSegments;
 }
 
-static void createGenomeDimensions(RandNumberGen &rng, Alignment *alignment, hal_size_t minSegmentLength,
+static void createGenomeDimensions(RandNumberGen &rng, AlignmentPtr alignment, hal_size_t minSegmentLength,
                                    hal_size_t maxSegmentLength, hal_size_t minSegments, hal_size_t maxSegments,
                                    deque<string> &genomeNameQueue) {
     Genome *genome = alignment->openGenome(genomeNameQueue.back());
@@ -215,7 +215,7 @@ static void createGenomeDimensions(RandNumberGen &rng, Alignment *alignment, hal
     }
 }
 
-void hal::createRandomDimensions(RandNumberGen &rng, Alignment *alignment, hal_size_t minSegmentLength,
+void hal::createRandomDimensions(RandNumberGen &rng, AlignmentPtr alignment, hal_size_t minSegmentLength,
                                  hal_size_t maxSegmentLength, hal_size_t minSegments, hal_size_t maxSegments) {
     deque<string> genomeNameQueue;
     genomeNameQueue.push_front(alignment->getRootName());
@@ -225,7 +225,7 @@ void hal::createRandomDimensions(RandNumberGen &rng, Alignment *alignment, hal_s
     }
 }
 
-static void createRandomRootGenome(RandNumberGen &rng, Alignment *alignment, Genome *genome) {
+static void createRandomRootGenome(RandNumberGen &rng, AlignmentPtr alignment, Genome *genome) {
     DnaIteratorPtr dnaIt = genome->getDnaIterator();
     hal_size_t length = genome->getSequenceLength();
     for (hal_size_t i = 0; i < length; ++i) {
@@ -235,7 +235,7 @@ static void createRandomRootGenome(RandNumberGen &rng, Alignment *alignment, Gen
     dnaIt->flush();
 }
 
-static void createRandomDescendantGenome(RandNumberGen &rng, Alignment *alignment, Genome *genome, Genome *parent) {
+static void createRandomDescendantGenome(RandNumberGen &rng, AlignmentPtr alignment, Genome *genome, Genome *parent) {
     set<pair<hal_index_t, hal_index_t>> edgeSet;
     vector<string> parentChildNames = alignment->getChildNames(parent->getName());
     hal_size_t indexInParent = parentChildNames.size();
@@ -256,7 +256,7 @@ static void createRandomDescendantGenome(RandNumberGen &rng, Alignment *alignmen
     }
 }
 
-void hal::createRandomGenome(RandNumberGen &rng, Alignment *alignment, Genome *genome) {
+void hal::createRandomGenome(RandNumberGen &rng, AlignmentPtr alignment, Genome *genome) {
     Genome *parent = genome->getParent();
     if (parent == NULL) {
         createRandomRootGenome(rng, alignment, genome);

--- a/api/tests/halRandomData.h
+++ b/api/tests/halRandomData.h
@@ -14,17 +14,17 @@
 namespace hal {
     class RandNumberGen;
 
-    void createRandomAlignment(RandNumberGen &rng, Alignment *emptyAlignment, double meanDegree, double maxBranchLength,
+    void createRandomAlignment(RandNumberGen &rng, AlignmentPtr emptyAlignment, double meanDegree, double maxBranchLength,
                                hal_size_t minGenomes, hal_size_t maxGenomes, hal_size_t minSegmentLength,
                                hal_size_t maxSegmentLength, hal_size_t minSegments, hal_size_t maxSegments);
 
-    void createRandomTree(RandNumberGen &rng, Alignment *emptyAlignment, double meanDegree, double maxBranchLength,
+    void createRandomTree(RandNumberGen &rng, AlignmentPtr emptyAlignment, double meanDegree, double maxBranchLength,
                           hal_size_t minGenomes, hal_size_t maxGenomes);
 
-    void createRandomDimensions(RandNumberGen &rng, Alignment *alignment, hal_size_t minSegmentLength,
+    void createRandomDimensions(RandNumberGen &rng, AlignmentPtr alignment, hal_size_t minSegmentLength,
                                 hal_size_t maxSegmentLength, hal_size_t minSegments, hal_size_t maxSegments);
 
-    void createRandomGenome(RandNumberGen &rng, Alignment *alignment, Genome *genome);
+    void createRandomGenome(RandNumberGen &rng, AlignmentPtr alignment, Genome *genome);
 
     void createRandomSegment(RandNumberGen &rng, Genome *genome, hal_size_t indexInParent,
                              std::set<std::pair<hal_index_t, hal_index_t>> &edgeSet, TopSegmentIteratorPtr topIter,

--- a/api/tests/halRearrangementTest.cpp
+++ b/api/tests/halRearrangementTest.cpp
@@ -15,7 +15,7 @@ using namespace std;
 using namespace hal;
 
 struct RearrangementInsertionTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         size_t numSequences = 3;
         size_t numSegmentsPerSequence = 10;
         size_t segmentLength = 50;
@@ -47,7 +47,7 @@ struct RearrangementInsertionTest : public AlignmentTest {
         // insertion larger than gap threshold but that contains gaps
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi;
         TopSegmentIteratorPtr ti;
 
@@ -69,7 +69,7 @@ struct RearrangementInsertionTest : public AlignmentTest {
 };
 
 struct RearrangementSimpleInversionTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         size_t numSequences = 3;
         size_t numSegmentsPerSequence = 10;
         size_t segmentLength = 50;
@@ -98,7 +98,7 @@ struct RearrangementSimpleInversionTest : public AlignmentTest {
         ti->getTopSegment()->setParentReversed(true);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi;
         TopSegmentIteratorPtr ti;
 
@@ -122,7 +122,7 @@ struct RearrangementSimpleInversionTest : public AlignmentTest {
 };
 
 struct RearrangementGappedInversionTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         size_t numSequences = 3;
         size_t numSegmentsPerSequence = 10;
         size_t segmentLength = 5;
@@ -174,7 +174,7 @@ struct RearrangementGappedInversionTest : public AlignmentTest {
         ti->getTopSegment()->setParentReversed(true);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi;
         TopSegmentIteratorPtr ti;
 

--- a/api/tests/halSegmentTestSupport.h
+++ b/api/tests/halSegmentTestSupport.h
@@ -121,7 +121,7 @@ struct BottomSegmentStruct {
     }
 };
 
-static inline void addIdenticalParentChild(Alignment *alignment, size_t numSequences, size_t numSegmentsPerSequence, size_t segmentLength) {
+static inline void addIdenticalParentChild(AlignmentPtr alignment, size_t numSequences, size_t numSegmentsPerSequence, size_t segmentLength) {
     vector<Sequence::Info> seqVec(numSequences);
 
     BottomSegmentIteratorPtr bi;

--- a/api/tests/halSequenceTest.cpp
+++ b/api/tests/halSequenceTest.cpp
@@ -21,7 +21,7 @@ using namespace std;
 using namespace hal;
 
 struct SequenceCreateTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -36,7 +36,7 @@ struct SequenceCreateTest : public AlignmentTest {
         ancGenome->setDimensions(seqVec);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("AncGenome");
 
         hal_size_t numSequences = ancGenome->getNumSequences();
@@ -88,7 +88,7 @@ struct SequenceCreateTest : public AlignmentTest {
 };
 
 struct SequenceIteratorTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -104,7 +104,7 @@ struct SequenceIteratorTest : public AlignmentTest {
         ancGenome->setDimensions(seqVec);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("AncGenome");
 
         hal_size_t numSequences = ancGenome->getNumSequences();
@@ -140,7 +140,7 @@ struct SequenceIteratorTest : public AlignmentTest {
 };
 
 struct SequenceUpdateTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         hal_size_t alignmentSize = alignment->getNumGenomes();
         CuAssertTrue(_testCase, alignmentSize == 0);
 
@@ -172,7 +172,7 @@ struct SequenceUpdateTest : public AlignmentTest {
         ancGenome->updateBottomDimensions(updateVec);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("AncGenome");
 
         hal_size_t numSequences = ancGenome->getNumSequences();
@@ -227,7 +227,7 @@ struct SequenceUpdateTest : public AlignmentTest {
 };
 
 struct SequenceRenameTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *ancGenome = alignment->addRootGenome("AncGenome", 0);
 
         vector<Sequence::Info> seqVec;
@@ -244,7 +244,7 @@ struct SequenceRenameTest : public AlignmentTest {
         ancGenome->getSequence("short")->setName("again");
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("AncGenome");
 
         CuAssertTrue(_testCase, ancGenome->getNumSequences() == 3);

--- a/api/tests/halTopSegmentTest.cpp
+++ b/api/tests/halTopSegmentTest.cpp
@@ -17,7 +17,7 @@ using namespace hal;
 struct TopSegmentSimpleIteratorTest : public AlignmentTest {
     std::vector<TopSegmentStruct> _topSegments;
 
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *ancGenome = alignment->addRootGenome("Anc0", 0);
         size_t numChildren = 9;
         for (size_t i = 0; i < numChildren; ++i) {
@@ -45,7 +45,7 @@ struct TopSegmentSimpleIteratorTest : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("Anc0");
         CuAssertTrue(_testCase, ancGenome->getNumTopSegments() == _topSegments.size());
         TopSegmentIteratorPtr tsIt = ancGenome->getTopSegmentIterator(0);
@@ -100,7 +100,7 @@ struct TopSegmentSequenceTest : public AlignmentTest {
     std::vector<TopSegmentStruct> _topSegments;
     std::vector<std::string> _sequences;
 
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *ancGenome = alignment->addRootGenome("Anc0", 0);
         vector<Sequence::Info> seqVec(1);
         seqVec[0] = Sequence::Info("Sequence", 1000000, 5000, 700000);
@@ -111,7 +111,7 @@ struct TopSegmentSequenceTest : public AlignmentTest {
         tsIt->getTopSegment()->setCoordinates(500, 9);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *ancGenome = alignment->openGenome("Anc0");
         TopSegmentIteratorPtr tsIt = ancGenome->getTopSegmentIterator(100);
         CuAssertTrue(_testCase, tsIt->getTopSegment()->getStartPosition() == 500);
@@ -126,7 +126,7 @@ struct TopSegmentSequenceTest : public AlignmentTest {
 };
 
 struct TopSegmentIteratorParseTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         vector<Sequence::Info> seqVec(1);
 
         BottomSegmentIteratorPtr bi;
@@ -202,7 +202,7 @@ struct TopSegmentIteratorParseTest : public AlignmentTest {
         bs.applyTo(bi);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi;
         TopSegmentIteratorPtr ti;
 
@@ -253,7 +253,7 @@ struct TopSegmentIteratorParseTest : public AlignmentTest {
 };
 
 struct TopSegmentIteratorToSiteTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         vector<Sequence::Info> seqVec(1);
 
         TopSegmentIteratorPtr ti;
@@ -305,7 +305,7 @@ struct TopSegmentIteratorToSiteTest : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         TopSegmentIteratorPtr bi;
 
         // case 1
@@ -319,7 +319,7 @@ struct TopSegmentIteratorToSiteTest : public AlignmentTest {
 };
 
 struct TopSegmentIteratorReverseTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         vector<Sequence::Info> seqVec(1);
 
         BottomSegmentIteratorPtr bi;
@@ -357,7 +357,7 @@ struct TopSegmentIteratorReverseTest : public AlignmentTest {
         bs.applyTo(bi);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi;
         TopSegmentIteratorPtr ti, ti2;
 
@@ -419,7 +419,7 @@ struct TopSegmentIteratorReverseTest : public AlignmentTest {
 };
 
 struct TopSegmentIsGapTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         size_t numSequences = 3;
         vector<Sequence::Info> seqVec(numSequences);
 
@@ -480,7 +480,7 @@ struct TopSegmentIsGapTest : public AlignmentTest {
         ti->getTopSegment()->setParentIndex(NULL_INDEX);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         BottomSegmentIteratorPtr bi;
         TopSegmentIteratorPtr ti;
 

--- a/api/tests/halValidateTest.cpp
+++ b/api/tests/halValidateTest.cpp
@@ -22,38 +22,38 @@ using namespace hal;
 static RandNumberGen rng;
 
 struct ValidateSmallTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         createRandomAlignment(rng, alignment, 0.75, 0.1, 2, 5, 10, 1000, 5, 10);
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
     }
 };
 
 struct ValidateMediumTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         createRandomAlignment(rng, alignment, 1.25, 0.7, 10, 20, 2, 50, 1000, 50000);
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
     }
 };
 
 struct ValidateLargeTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         createRandomAlignment(rng, alignment, 2.0, 1.0, 50, 100, 2, 10, 10000, 500000);
     }
 
-    void checkCallBack(const Alignment *alignment) {
-        validateAlignment(alignment);
+    void checkCallBack(AlignmentConstPtr alignment) {
+        validateAlignment(alignment.get());
     }
 
 };
 
 struct ValidateManyGenomesTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         // hdf5 runs out of memory on Travis.
         if (alignment->getStorageFormat() == "mmap") {
             cout << "running" << endl;
@@ -61,9 +61,9 @@ struct ValidateManyGenomesTest : public AlignmentTest {
         }
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         if (alignment->getStorageFormat() == "mmap") {
-            validateAlignment(alignment);
+            validateAlignment(alignment.get());
         }
     }
 };

--- a/extract/impl/halExtract.cpp
+++ b/extract/impl/halExtract.cpp
@@ -12,13 +12,13 @@
 using namespace std;
 using namespace hal;
 
-static void getDimensions(const Alignment *outAlignment, const Genome *genome, vector<Sequence::Info> &dimensions);
+static void getDimensions(AlignmentConstPtr outAlignment, const Genome *genome, vector<Sequence::Info> &dimensions);
 
 static void copyGenome(const Genome *inGenome, Genome *outGenome);
 
-static void extractTree(const Alignment *inAlignment, AlignmentPtr outAlignment, const string &rootName);
+static void extractTree(AlignmentConstPtr inAlignment, AlignmentPtr outAlignment, const string &rootName);
 
-static void extract(const Alignment *inAlignment, AlignmentPtr outAlignment, const string &rootName);
+static void extract(AlignmentConstPtr inAlignment, AlignmentPtr outAlignment, const string &rootName);
 
 static void initParser(CLParser &optionsParser) {
     optionsParser.addArgument("inHalPath", "input hal file");
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
     }
 
     try {
-        const Alignment *inAlignment = openHalAlignment(inHalPath, &optionsParser);
+        AlignmentConstPtr inAlignment(openHalAlignment(inHalPath, &optionsParser));
         if (inAlignment->getNumGenomes() == 0) {
             throw hal_exception("input hal alignmenet is empty");
         }
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-void getDimensions(const Alignment *outAlignment, const Genome *genome, vector<Sequence::Info> &dimensions) {
+void getDimensions(AlignmentConstPtr outAlignment, const Genome *genome, vector<Sequence::Info> &dimensions) {
     assert(dimensions.size() == 0);
 
     bool root = outAlignment->getParentName(genome->getName()).empty();
@@ -143,7 +143,7 @@ void copyGenome(const Genome *inGenome, Genome *outGenome) {
     }
 }
 
-static void extractTree(const Alignment *inAlignment, AlignmentPtr outAlignment, const string &rootName) {
+static void extractTree(AlignmentConstPtr inAlignment, AlignmentPtr outAlignment, const string &rootName) {
     const Genome *genome = inAlignment->openGenome(rootName);
     Genome *newGenome = NULL;
     if (outAlignment->getNumGenomes() == 0 || genome->getParent() == NULL) {
@@ -165,7 +165,7 @@ static void extractTree(const Alignment *inAlignment, AlignmentPtr outAlignment,
     }
 }
 
-void extract(const Alignment *inAlignment, AlignmentPtr outAlignment, const string &rootName) {
+void extract(AlignmentConstPtr inAlignment, AlignmentPtr outAlignment, const string &rootName) {
     const Genome *genome = inAlignment->openGenome(rootName);
     Genome *newGenome = outAlignment->openGenome(rootName);
     assert(newGenome != NULL);

--- a/extract/impl/halMaskExtractMain.cpp
+++ b/extract/impl/halMaskExtractMain.cpp
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
         }
 
         MaskExtractor mask;
-        mask.extract(alignment.get(), genome, bedStream, extend, extendPct);
+        mask.extract(alignment, genome, bedStream, extend, extendPct);
 
         if (newBed) {
             delete bedStream;

--- a/extract/impl/halMaskExtractor.cpp
+++ b/extract/impl/halMaskExtractor.cpp
@@ -21,7 +21,7 @@ MaskExtractor::MaskExtractor() {
 MaskExtractor::~MaskExtractor() {
 }
 
-void MaskExtractor::extract(const Alignment *alignment, const Genome *genome, ostream *bedStream, hal_size_t extend,
+void MaskExtractor::extract(AlignmentConstPtr alignment, const Genome *genome, ostream *bedStream, hal_size_t extend,
                             double extendPct) {
     _alignment = AlignmentConstPtr(alignment);
     _genome = genome;

--- a/extract/inc/halMaskExtractor.h
+++ b/extract/inc/halMaskExtractor.h
@@ -20,7 +20,7 @@ namespace hal {
         MaskExtractor();
         virtual ~MaskExtractor();
 
-        void extract(const Alignment *alignment, const Genome *genome, std::ostream *bedStream, hal_size_t extend,
+        void extract(AlignmentConstPtr alignment, const Genome *genome, std::ostream *bedStream, hal_size_t extend,
                      double extendPct);
 
       protected:

--- a/extract/tests/hal4dExtractTest.cpp
+++ b/extract/tests/hal4dExtractTest.cpp
@@ -6,7 +6,7 @@ using namespace std;
 using namespace hal;
 
 struct ConservedBed4dExtractTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *root = alignment->addRootGenome("root");
         Genome *leaf1 = alignment->addLeafGenome("leaf1", "root", 1);
         Genome *leaf2 = alignment->addLeafGenome("leaf2", "root", 1);
@@ -52,7 +52,7 @@ struct ConservedBed4dExtractTest : public AlignmentTest {
         topIt->tseg()->setBottomParseIndex(NULL_INDEX);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *genome = alignment->openGenome("root");
         stringstream bedFile("rootSequence\t0\t192\tFORWARD\t0\t+\n"
                              "rootSequence\t0\t192\tREV\t0\t-\n");
@@ -73,7 +73,7 @@ struct ConservedBed4dExtractTest : public AlignmentTest {
 };
     
 struct Bed4dExtractTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *genome = alignment->addRootGenome("root");
         vector<Sequence::Info> seqVec(1);
         seqVec[0] = Sequence::Info("rootSequence", 192, 0, 0);
@@ -84,7 +84,7 @@ struct Bed4dExtractTest : public AlignmentTest {
                           "ggatgcagccgcggctggaggcgggggtgtagtcgtggtttaatactagtattcatcctcgtcttgatgctggtgtttattcttgttt");
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *genome = alignment->openGenome("root");
         stringstream bedFile("rootSequence\t0\t192\tFORWARD\t0\t+\n"
                              "rootSequence\t0\t192\tREV\t0\t-\n");
@@ -102,7 +102,7 @@ struct Bed4dExtractTest : public AlignmentTest {
 };
 
 struct Block4dExtractTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *genome = alignment->addRootGenome("root");
         vector<Sequence::Info> seqVec(1);
         seqVec[0] = Sequence::Info("rootSequence", 192, 0, 0);
@@ -113,7 +113,7 @@ struct Block4dExtractTest : public AlignmentTest {
                           "ggatgcagccgcggctggaggcgggggtgtagtcgtggtttaatactagtattcatcctcgtcttgatgctggtgtttattcttgttt");
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *genome = alignment->openGenome("root");
         // test frame shift
         stringstream bedFile("rootSequence\t0\t192\tFORWARD\t0\t+\t0\t192\t0\t3\t17,6,7\t0,30,60\n"
@@ -134,7 +134,7 @@ struct Block4dExtractTest : public AlignmentTest {
 };
 
 struct ConservedBlock4dExtractTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *root = alignment->addRootGenome("root");
         Genome *leaf1 = alignment->addLeafGenome("leaf1", "root", 1);
         Genome *leaf2 = alignment->addLeafGenome("leaf2", "root", 1);
@@ -208,7 +208,7 @@ struct ConservedBlock4dExtractTest : public AlignmentTest {
         topIt->tseg()->setBottomParseIndex(NULL_INDEX);
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *genome = alignment->openGenome("root");
         // test frame shift
         stringstream bedFile("rootSequence\t0\t192\tFORWARD\t0\t+\t0\t192\t0\t3\t17,6,7\t0,30,60\n"
@@ -236,7 +236,7 @@ struct ConservedBlock4dExtractTest : public AlignmentTest {
 };
 
 struct CDS4dExtractTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment) {
+    void createCallBack(AlignmentPtr alignment) {
         Genome *genome = alignment->addRootGenome("root");
         vector<Sequence::Info> seqVec(1);
         seqVec[0] = Sequence::Info("rootSequence", 213, 0, 0);
@@ -249,7 +249,7 @@ struct CDS4dExtractTest : public AlignmentTest {
                           "tgttt");
     }
 
-    void checkCallBack(const Alignment *alignment) {
+    void checkCallBack(AlignmentConstPtr alignment) {
         const Genome *genome = alignment->openGenome("root");
         stringstream bedFile("rootSequence\t1\t212\tFORWARD\t0\t+\t21\t88\t0\t5\t10,19,6,8,10\t0,18,50,80,90\n"
                              "rootSequence\t1\t213\tREV\t0\t-\t25\t198\t0\t2\t13,17\t20,195\n");

--- a/liftover/impl/halLiftover.cpp
+++ b/liftover/impl/halLiftover.cpp
@@ -20,7 +20,7 @@ Liftover::Liftover()
 Liftover::~Liftover() {
 }
 
-void Liftover::convert(const Alignment *alignment, const Genome *srcGenome, istream *inBedStream, const Genome *tgtGenome,
+void Liftover::convert(AlignmentConstPtr alignment, const Genome *srcGenome, istream *inBedStream, const Genome *tgtGenome,
                        ostream *outBedStream, int bedType, bool traverseDupes,
                        bool outPSL, bool outPSLWithName, const Genome *coalescenceLimit) {
     _srcGenome = srcGenome;

--- a/liftover/impl/halLiftoverMain.cpp
+++ b/liftover/impl/halLiftoverMain.cpp
@@ -127,7 +127,7 @@ int main(int argc, char **argv) {
         }
 
         BlockLiftover liftover;
-        liftover.convert(alignment.get(), srcGenome, srcBedPtr, tgtGenome, tgtBedPtr, bedType,
+        liftover.convert(alignment, srcGenome, srcBedPtr, tgtGenome, tgtBedPtr, bedType,
                          !noDupes, outPSL, outPSLWithName, coalescenceLimit);
 
 

--- a/liftover/impl/halWiggleLiftover.cpp
+++ b/liftover/impl/halWiggleLiftover.cpp
@@ -23,15 +23,15 @@ WiggleLiftover::WiggleLiftover() {
 WiggleLiftover::~WiggleLiftover() {
 }
 
-void WiggleLiftover::preloadOutput(const Alignment *alignment, const Genome *tgtGenome, istream *inputFile) {
+void WiggleLiftover::preloadOutput(AlignmentConstPtr alignment, const Genome *tgtGenome, istream *inputFile) {
     WiggleLoader loader;
     _outVals.init(tgtGenome->getSequenceLength(), DefaultValue, DefaultTileSize);
     loader.load(alignment, tgtGenome, inputFile, &_outVals);
 }
 
-void WiggleLiftover::convert(const Alignment *alignment, const Genome *srcGenome, istream *inputFile, const Genome *tgtGenome,
+void WiggleLiftover::convert(AlignmentConstPtr alignment, const Genome *srcGenome, istream *inputFile, const Genome *tgtGenome,
                              ostream *outputFile, bool traverseDupes, bool unique) {
-    _alignment = AlignmentConstPtr(alignment);
+    _alignment = alignment;
     _srcGenome = srcGenome;
     _tgtGenome = tgtGenome;
     _outStream = outputFile;

--- a/liftover/impl/halWiggleLiftoverMain.cpp
+++ b/liftover/impl/halWiggleLiftoverMain.cpp
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
             // with the new data from the liftover.
             ifstream tgtWig(tgtWigPath.c_str());
             if (tgtWig) {
-                liftover.preloadOutput(alignment.get(), tgtGenome, &tgtWig);
+                liftover.preloadOutput(alignment, tgtGenome, &tgtWig);
             }
         }
 
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        liftover.convert(alignment.get(), srcGenome, srcWigPtr, tgtGenome, tgtWigPtr, !noDupes, unique);
+        liftover.convert(alignment, srcGenome, srcWigPtr, tgtGenome, tgtWigPtr, !noDupes, unique);
     } catch (hal_exception &e) {
         cerr << "hal exception caught: " << e.what() << endl;
         return 1;

--- a/liftover/impl/halWiggleLoader.cpp
+++ b/liftover/impl/halWiggleLoader.cpp
@@ -19,7 +19,7 @@ WiggleLoader::WiggleLoader() {
 WiggleLoader::~WiggleLoader() {
 }
 
-void WiggleLoader::load(const Alignment *alignment, const Genome *genome, istream *inputFile, WiggleTiles<double> *vals) {
+void WiggleLoader::load(AlignmentConstPtr alignment, const Genome *genome, istream *inputFile, WiggleTiles<double> *vals) {
     _alignment = AlignmentConstPtr(alignment);
     _srcGenome = genome;
     _srcSequence = NULL;

--- a/liftover/inc/halLiftover.h
+++ b/liftover/inc/halLiftover.h
@@ -22,7 +22,7 @@ namespace hal {
         Liftover();
         virtual ~Liftover();
 
-        void convert(const Alignment *alignment, const Genome *srcGenome, std::istream *inputFile, const Genome *tgtGenome,
+        void convert(AlignmentConstPtr alignment, const Genome *srcGenome, std::istream *inputFile, const Genome *tgtGenome,
                      std::ostream *outputFile, int bedType = 0,
                      bool traverseDupes = true, bool outPSL = false, bool outPSLWithName = false,
                      const Genome *coalescenceLimit = NULL);

--- a/liftover/inc/halWiggleLiftover.h
+++ b/liftover/inc/halWiggleLiftover.h
@@ -22,9 +22,9 @@ namespace hal {
         WiggleLiftover();
         virtual ~WiggleLiftover();
 
-        void preloadOutput(const Alignment *alignment, const Genome *tgtGenome, std::istream *inputFile);
+        void preloadOutput(AlignmentConstPtr alignment, const Genome *tgtGenome, std::istream *inputFile);
 
-        void convert(const Alignment *alignment, const Genome *srcGenome, std::istream *inputFile, const Genome *tgtGenome,
+        void convert(AlignmentConstPtr alignment, const Genome *srcGenome, std::istream *inputFile, const Genome *tgtGenome,
                      std::ostream *outputFile, bool traverseDupes = true, bool unique = false);
 
         static const double DefaultValue;

--- a/liftover/inc/halWiggleLoader.h
+++ b/liftover/inc/halWiggleLoader.h
@@ -25,7 +25,7 @@ namespace hal {
         WiggleLoader();
         virtual ~WiggleLoader();
 
-        void load(const Alignment *alignment, const Genome *genome, std::istream *inputFile, WiggleTiles<double> *vals);
+        void load(AlignmentConstPtr alignment, const Genome *genome, std::istream *inputFile, WiggleTiles<double> *vals);
 
       protected:
         virtual void visitLine();

--- a/liftover/tests/halLiftoverTests.cpp
+++ b/liftover/tests/halLiftoverTests.cpp
@@ -12,7 +12,7 @@
 using namespace std;
 using namespace hal;
 
-static void setupSharedAlignment(Alignment *alignment) {
+static void setupSharedAlignment(AlignmentPtr alignment) {
     Genome *root = alignment->addRootGenome("root");
     Genome *child1 = alignment->addLeafGenome("child1", "root", 1);
     Genome *leaf1 = alignment->addLeafGenome("leaf1", "root", 1);
@@ -251,7 +251,7 @@ static void setupSharedAlignment(Alignment *alignment) {
     alignment->closeGenome(leaf3);
 }
 
-void BedLiftoverTest::liftAndCheck(const Alignment *alignment,
+void BedLiftoverTest::liftAndCheck(AlignmentConstPtr alignment,
                                    const Genome *srcGenome,
                                    const Genome *tgtGenome,
                                    const string& inBed,
@@ -269,7 +269,7 @@ void BedLiftoverTest::liftAndCheck(const Alignment *alignment,
     CuAssertTrue(_testCase, outStream.str() == expectBed);
 }
 
-void BedLiftoverTest::testOneBranchLifts(const Alignment *alignment) {
+void BedLiftoverTest::testOneBranchLifts(AlignmentConstPtr alignment) {
     BlockLiftover liftover;
     const Genome *root = alignment->openGenome("root");
     const Genome *child1 = alignment->openGenome("child1");
@@ -316,7 +316,7 @@ void BedLiftoverTest::testOneBranchLifts(const Alignment *alignment) {
     alignment->closeGenome(leaf3);
 }
 
-void BedLiftoverTest::testMultiBranchLifts(const Alignment *alignment) {
+void BedLiftoverTest::testMultiBranchLifts(AlignmentConstPtr alignment) {
     BlockLiftover liftover;
     const Genome *root = alignment->openGenome("root");
     const Genome *child1 = alignment->openGenome("child1");
@@ -378,11 +378,11 @@ void BedLiftoverTest::testMultiBranchLifts(const Alignment *alignment) {
     alignment->closeGenome(leaf3);
 }
 
-void BedLiftoverTest::createCallBack(Alignment *alignment) {
+void BedLiftoverTest::createCallBack(AlignmentPtr alignment) {
     setupSharedAlignment(alignment);
 }
 
-void BedLiftoverTest::checkCallBack(const Alignment *alignment) {
+void BedLiftoverTest::checkCallBack(AlignmentConstPtr alignment) {
     testOneBranchLifts(alignment);
     testMultiBranchLifts(alignment);
 }
@@ -399,7 +399,7 @@ void WiggleLiftoverTest::checkWigHasEntry(vector<string> &wig,
 }
 */
 
-void WiggleLiftoverTest::testOneBranchLifts(const Alignment *alignment) {
+void WiggleLiftoverTest::testOneBranchLifts(AlignmentConstPtr alignment) {
 #if 0 // FIXME: implement
     const Genome *root = alignment->openGenome("root");
     const Genome *child1 = alignment->openGenome("child1");
@@ -431,14 +431,14 @@ void WiggleLiftoverTest::testOneBranchLifts(const Alignment *alignment) {
 #endif
 }
 
-void WiggleLiftoverTest::testMultiBranchLifts(const Alignment *alignment) {
+void WiggleLiftoverTest::testMultiBranchLifts(AlignmentConstPtr alignment) {
 }
 
-void WiggleLiftoverTest::createCallBack(Alignment *alignment) {
+void WiggleLiftoverTest::createCallBack(AlignmentPtr alignment) {
     setupSharedAlignment(alignment);
 }
 
-void WiggleLiftoverTest::checkCallBack(const Alignment *alignment) {
+void WiggleLiftoverTest::checkCallBack(AlignmentConstPtr alignment) {
     testOneBranchLifts(alignment);
     testMultiBranchLifts(alignment);
 }

--- a/liftover/tests/halLiftoverTests.h
+++ b/liftover/tests/halLiftoverTests.h
@@ -19,24 +19,24 @@ using namespace hal;
 
 struct BedLiftoverTest : public AlignmentTest {
     private:
-    void liftAndCheck(const Alignment *alignment,
+    void liftAndCheck(AlignmentConstPtr alignment,
                       const Genome *srcGenome,
                       const Genome *tgtGenome,
                       const std::string& inBed,
                       const std::string& expectBed,
                       bool outPSL = false, bool outPSLWithName = false);
     public:
-    void createCallBack(Alignment *alignment);
-    void checkCallBack(const Alignment *alignment);
-    void testOneBranchLifts(const Alignment *alignment);
-    void testMultiBranchLifts(const Alignment *alignment);
+    void createCallBack(AlignmentPtr alignment);
+    void checkCallBack(AlignmentConstPtr alignment);
+    void testOneBranchLifts(AlignmentConstPtr alignment);
+    void testMultiBranchLifts(AlignmentConstPtr alignment);
 };
 
 struct WiggleLiftoverTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment);
-    void checkCallBack(const Alignment *alignment);
-    void testOneBranchLifts(const Alignment *alignment);
-    void testMultiBranchLifts(const Alignment *alignment);
+    void createCallBack(AlignmentPtr alignment);
+    void checkCallBack(AlignmentConstPtr alignment);
+    void testOneBranchLifts(AlignmentConstPtr alignment);
+    void testMultiBranchLifts(AlignmentConstPtr alignment);
 };
 
 CuSuite *halLiftoverTestSuite();

--- a/lod/impl/halLodExtract.cpp
+++ b/lod/impl/halLodExtract.cpp
@@ -23,11 +23,11 @@ LodExtract::LodExtract() {
 LodExtract::~LodExtract() {
 }
 
-void LodExtract::createInterpolatedAlignment(const Alignment *inAlignment, Alignment *outAlignment, double scale,
+void LodExtract::createInterpolatedAlignment(AlignmentConstPtr inAlignment, AlignmentPtr outAlignment, double scale,
                                              const string &tree, const string &rootName, bool keepSequences, bool allSequences,
                                              double probeFrac, double minSeqFrac) {
-    _inAlignment = AlignmentConstPtr(inAlignment);
-    _outAlignment = AlignmentPtr(outAlignment);
+    _inAlignment = inAlignment;
+    _outAlignment = outAlignment;
     _keepSequences = keepSequences;
     _allSequences = allSequences;
     _probeFrac = probeFrac;
@@ -124,7 +124,7 @@ void LodExtract::convertInternalNode(const string &genomeName, double scale) {
     const Genome *grandParent = NULL; // TEMP HACK  parent->getParent();
     hal_size_t minAvgBlockSize = getMinAvgBlockSize(parent, children, grandParent);
     hal_size_t step = (hal_size_t)(scale * minAvgBlockSize);
-    _graph.build(_inAlignment.get(), parent, children, grandParent, step, _allSequences, _probeFrac, _minSeqFrac);
+    _graph.build(_inAlignment, parent, children, grandParent, step, _allSequences, _probeFrac, _minSeqFrac);
 
     map<const Sequence *, hal_size_t> segmentCounts;
     countSegmentsInGraph(segmentCounts);

--- a/lod/impl/halLodExtractMain.cpp
+++ b/lod/impl/halLodExtractMain.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
         }
 
         LodExtract lodExtract;
-        lodExtract.createInterpolatedAlignment(inAlignment.get(), outAlignment.get(), scale, outTree, rootName, keepSequences,
+        lodExtract.createInterpolatedAlignment(inAlignment, outAlignment, scale, outTree, rootName, keepSequences,
                                                allSequences, probeFrac, minSeqFrac);
     } catch (hal_exception &e) {
         cerr << "hal exception caught: " << e.what() << endl;

--- a/lod/impl/halLodGraph.cpp
+++ b/lod/impl/halLodGraph.cpp
@@ -37,7 +37,7 @@ void LodGraph::erase() {
     _telomeres.clear();
 }
 
-void LodGraph::build(const Alignment *alignment, const Genome *parent, const vector<const Genome *> &children,
+void LodGraph::build(AlignmentConstPtr alignment, const Genome *parent, const vector<const Genome *> &children,
                      const Genome *grandParent, hal_size_t step, bool allSequences, double probeFrac, double minSeqFrac) {
     erase();
     _alignment = AlignmentConstPtr(alignment);

--- a/lod/impl/halLodManager.cpp
+++ b/lod/impl/halLodManager.cpp
@@ -116,7 +116,7 @@ void LodManager::loadSingeHALFile(const string &halPath, const CLParser *options
     checkMap(halPath);
 }
 
-const Alignment *LodManager::getAlignment(hal_size_t queryLength, bool needDNA) {
+AlignmentConstPtr LodManager::getAlignment(hal_size_t queryLength, bool needDNA) {
     assert(_map.size() > 0);
     AlignmentMap::iterator mapIt;
     if (needDNA == true) {
@@ -133,10 +133,10 @@ const Alignment *LodManager::getAlignment(hal_size_t queryLength, bool needDNA) 
     }
     if (alignment.get() == NULL) {
         alignment = AlignmentConstPtr(openHalAlignment(mapIt->second.first, _options));
-        checkAlignment(mapIt->first, mapIt->second.first, alignment.get());
+        checkAlignment(mapIt->first, mapIt->second.first, alignment);
     }
     assert(mapIt->second.second.get() != NULL);
-    return alignment.get();
+    return alignment;
 }
 
 bool LodManager::isLod0(hal_size_t queryLength) const {
@@ -172,7 +172,7 @@ void LodManager::checkMap(const string &lodPath) {
     }
 }
 
-void LodManager::checkAlignment(hal_size_t minQuery, const string &path, const Alignment *alignment) {
+void LodManager::checkAlignment(hal_size_t minQuery, const string &path, AlignmentConstPtr alignment) {
     if (alignment->getNumGenomes() == 0) {
         throw hal_exception("No genomes found in base alignment specified in " + path);
     }

--- a/lod/inc/halLodExtract.h
+++ b/lod/inc/halLodExtract.h
@@ -33,7 +33,7 @@ namespace hal {
         LodExtract();
         ~LodExtract();
 
-        void createInterpolatedAlignment(const Alignment *inAlignment, Alignment *outAlignment, double scale,
+        void createInterpolatedAlignment(AlignmentConstPtr inAlignment, AlignmentPtr outAlignment, double scale,
                                          const std::string &tree, const std::string &rootName, bool keepSequences,
                                          bool allSequences, double probeFrac, double minSeqFrac);
 

--- a/lod/inc/halLodGraph.h
+++ b/lod/inc/halLodGraph.h
@@ -38,7 +38,7 @@ namespace hal {
          * entire graph is stored in memory in a special structure (ie not within
          * HAL).  The step parameter dictates how coarse-grained the interpolation
          * is:  every step bases are sampled.  */
-        void build(const Alignment *alignment, const Genome *parent, const std::vector<const Genome *> &children,
+        void build(AlignmentConstPtr alignment, const Genome *parent, const std::vector<const Genome *> &children,
                    const Genome *grandParent, hal_size_t step, bool allSequences, double probeFrac, double minSeqFrac);
 
         /** Help debuggin and tuning */

--- a/lod/inc/halLodManager.h
+++ b/lod/inc/halLodManager.h
@@ -40,7 +40,7 @@ namespace hal {
          * lodFile containing only "0 halPath"*/
         void loadSingeHALFile(const std::string &halPath, const CLParser *options = NULL);
 
-        const Alignment *getAlignment(hal_size_t queryLength, bool needDNA);
+        AlignmentConstPtr getAlignment(hal_size_t queryLength, bool needDNA);
 
         /** Check if query length corresponds to LOD 0 (ie original HAL) */
         bool isLod0(hal_size_t queryLenth) const;
@@ -58,7 +58,7 @@ namespace hal {
       private:
         std::string resolvePath(const std::string &lodPath, const std::string &halPath);
         void checkMap(const std::string &lodPath);
-        void checkAlignment(hal_size_t minQuery, const std::string &path, const Alignment *alignment);
+        void checkAlignment(hal_size_t minQuery, const std::string &path, AlignmentConstPtr alignment);
         void preloadAlignments();
 
         typedef std::pair<std::string, AlignmentConstPtr> PathAlign;

--- a/maf/impl/halMafWriteGenomes.cpp
+++ b/maf/impl/halMafWriteGenomes.cpp
@@ -133,7 +133,7 @@ void MafWriteGenomes::createGenomes() {
             Genome *childGenome = _alignment->openGenome(childName);
 
             childGenome->setDimensions(genomeDimensions);
-            if (_topSegment.get() == NULL && childGenome->getNumTopSegments() > 0) {
+            if (_topSegment == NULL && childGenome->getNumTopSegments() > 0) {
                 _topSegment = childGenome->getTopSegmentIterator();
                 _paraTop = childGenome->getTopSegmentIterator();
             }

--- a/maf/tests/halMafBlockTest.cpp
+++ b/maf/tests/halMafBlockTest.cpp
@@ -11,10 +11,10 @@
 using namespace std;
 using namespace hal;
 
-void MafBlockCreateTest::createCallBack(Alignment *alignment) {
+void MafBlockCreateTest::createCallBack(AlignmentPtr alignment) {
 }
 
-void MafBlockCreateTest::checkCallBack(const Alignment *alignment) {
+void MafBlockCreateTest::checkCallBack(AlignmentConstPtr alignment) {
 }
 
 void halMafBlockCreateTest(CuTest *testCase) {

--- a/maf/tests/halMafBlockTest.h
+++ b/maf/tests/halMafBlockTest.h
@@ -17,8 +17,8 @@
 using namespace hal;
 
 struct MafBlockCreateTest : public AlignmentTest {
-    void createCallBack(Alignment *alignment);
-    void checkCallBack(const Alignment *alignment);
+    void createCallBack(AlignmentPtr alignment);
+    void checkCallBack(AlignmentConstPtr alignment);
 };
 
 #endif

--- a/modify/ancestorsML.cpp
+++ b/modify/ancestorsML.cpp
@@ -121,7 +121,7 @@ void removeAndPrune(stTree *tree) {
 }
 
 // Build site-specific tree below this genome.
-void buildTree(const Alignment *alignment, const Genome *genome, hal_index_t pos, stTree *tree, bool reversed,
+void buildTree(AlignmentConstPtr alignment, const Genome *genome, hal_index_t pos, stTree *tree, bool reversed,
                map<string, int> *nameToId = NULL) {
     stTree_setLabel(tree, genome->getName().c_str());
     felsensteinData *data = (felsensteinData *)malloc(sizeof(felsensteinData));
@@ -328,7 +328,7 @@ void walkFelsenstein(TreeModel *mod, stTree *tree, char assignment, double thres
     }
 }
 
-void writeNucleotides(stTree *tree, const Alignment *alignment, const Genome *target, hal_index_t targetPos,
+void writeNucleotides(stTree *tree, AlignmentConstPtr alignment, const Genome *target, hal_index_t targetPos,
                       bool printWrites = false) {
     felsensteinData *data = (felsensteinData *)stTree_getClientData(tree);
     if (stTree_getChildNumber(tree) == 0) {
@@ -370,7 +370,7 @@ void freeClientData(stTree *tree) {
     free(data);
 }
 
-void reEstimate(TreeModel *mod, const Alignment *alignment, const Genome *genome, hal_index_t startPos, hal_index_t endPos,
+void reEstimate(TreeModel *mod, AlignmentConstPtr alignment, const Genome *genome, hal_index_t startPos, hal_index_t endPos,
                 map<string, int> &nameToId, double threshold, bool printWrites, bool writePosts) {
     threshold = log(threshold);
     stTree *tree = NULL;

--- a/modify/ancestorsML.h
+++ b/modify/ancestorsML.h
@@ -42,7 +42,7 @@ using namespace hal;
 
 void doFelsenstein(stTree *node, TreeModel *mod);
 
-void reEstimate(TreeModel *mod, const Alignment *alignment, const Genome *genome, hal_index_t startPos, hal_index_t endPos,
+void reEstimate(TreeModel *mod, AlignmentConstPtr alignment, const Genome *genome, hal_index_t startPos, hal_index_t endPos,
                 std::map<std::string, int> &nameToId, double threshold, bool printWrites, bool outputPosts);
 
 #endif

--- a/modify/ancestorsMLBed.h
+++ b/modify/ancestorsMLBed.h
@@ -10,13 +10,13 @@ using namespace hal;
 
 class AncestorsMLBed : public hal::BedScanner {
   public:
-    AncestorsMLBed(TreeModel *mod, const Alignment *alignment, const Genome *genome, std::map<std::string, int> &nameToId,
+    AncestorsMLBed(TreeModel *mod, AlignmentConstPtr alignment, const Genome *genome, std::map<std::string, int> &nameToId,
                    double threshold, bool printWrites, bool outputPosts)
         : _mod(mod), _alignment(alignment), _genome(genome), _nameToId(nameToId), _threshold(threshold),
           _printWrites(printWrites), _outputPosts(outputPosts){};
     void visitLine();
     TreeModel *_mod;
-    const Alignment *_alignment;
+    AlignmentConstPtr _alignment;
     const Genome *_genome;
     std::map<std::string, int> &_nameToId;
     double _threshold;

--- a/modify/ancestorsMLMain.cpp
+++ b/modify/ancestorsMLMain.cpp
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
     }
     lst_free(phastList);
 
-    Alignment *alignment = openHalAlignment(halPath, &optParser);
+    AlignmentPtr alignment = openHalAlignment(halPath, &optParser);
     const Genome *genome = alignment->openGenome(genomeName);
     if (genome->getNumChildren() == 0) {
         throw hal_exception("Genome " + genomeName + " is a leaf genome.");

--- a/modify/halAddToBranch.cpp
+++ b/modify/halAddToBranch.cpp
@@ -99,6 +99,6 @@ int main(int argc, char *argv[]) {
     // Copy the entire genome for the leaf from the bottom alignment.
     inLeafGenome->copy(outLeafGenome);
     if (!noMarkAncestors) {
-        markAncestorsForUpdate(mainAlignment.get(), insertName);
+        markAncestorsForUpdate(mainAlignment, insertName);
     }
 }

--- a/modify/halAppendSubtree.cpp
+++ b/modify/halAppendSubtree.cpp
@@ -26,7 +26,7 @@ static void initParser(CLParser &optionsParser) {
     optionsParser.addOptionFlag("merge", "merge appended root and node that is appended to", false);
 }
 
-void addSubtree(Alignment *mainAlignment, const Alignment *appendAlignment, string currNode) {
+void addSubtree(AlignmentPtr mainAlignment, AlignmentConstPtr appendAlignment, string currNode) {
     Genome *outGenome = mainAlignment->openGenome(currNode);
     const Genome *inGenome = appendAlignment->openGenome(currNode);
     vector<string> children = appendAlignment->getChildNames(currNode);
@@ -91,7 +91,7 @@ int main(int argc, char *argv[]) {
         }
         assert(branchLength == 0.0);
     }
-    addSubtree(mainAlignment.get(), appendAlignment.get(), rootName);
+    addSubtree(mainAlignment, appendAlignment, rootName);
 
     // Need proper bottom segments for parent genome
     Genome *mainParentGenome = mainAlignment->openGenome(parentName);
@@ -111,7 +111,7 @@ int main(int argc, char *argv[]) {
     }
 
     if (!noMarkAncestors) {
-        markAncestorsForUpdate(mainAlignment.get(), rootName);
+        markAncestorsForUpdate(mainAlignment, rootName);
     }
     return 0;
 }

--- a/modify/halRemoveGenome.cpp
+++ b/modify/halRemoveGenome.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {
     }
     AlignmentPtr alignment(openHalAlignment(inPath, &optionsParser, READ_ACCESS | WRITE_ACCESS));
     if (!noMarkAncestors) {
-        markAncestorsForUpdate(alignment.get(), deleteNode);
+        markAncestorsForUpdate(alignment, deleteNode);
     }
     alignment->removeGenome(deleteNode);
     return 0;

--- a/modify/halReplaceGenome.cpp
+++ b/modify/halReplaceGenome.cpp
@@ -31,7 +31,7 @@ static void initParser(CLParser &optionsParser) {
         false);
 }
 
-void copyFromTopAlignment(const Alignment *topAlignment, Alignment *mainAlignment, const string &genomeName) {
+void copyFromTopAlignment(AlignmentConstPtr topAlignment, AlignmentPtr mainAlignment, const string &genomeName) {
     Genome *mainReplacedGenome = mainAlignment->openGenome(genomeName);
     const Genome *topReplacedGenome = topAlignment->openGenome(genomeName);
     topReplacedGenome->copyTopDimensions(mainReplacedGenome);
@@ -56,7 +56,7 @@ void copyFromTopAlignment(const Alignment *topAlignment, Alignment *mainAlignmen
     }
 }
 
-void copyFromBottomAlignment(const Alignment *bottomAlignment, Alignment *mainAlignment, const string &genomeName) {
+void copyFromBottomAlignment(AlignmentConstPtr bottomAlignment, AlignmentPtr mainAlignment, const string &genomeName) {
     Genome *mainReplacedGenome = mainAlignment->openGenome(genomeName);
     const Genome *botReplacedGenome = bottomAlignment->openGenome(genomeName);
     // Add children if needed
@@ -139,10 +139,10 @@ int main(int argc, char *argv[]) {
         throw hal_exception("Root genome is also a leaf genome.");
     }
     if (useBottomAlignment) {
-        copyFromBottomAlignment(bottomAlignment.get(), mainAlignment.get(), genomeName);
+        copyFromBottomAlignment(bottomAlignment, mainAlignment, genomeName);
     }
     if (useTopAlignment) {
-        copyFromTopAlignment(topAlignment.get(), mainAlignment.get(), genomeName);
+        copyFromTopAlignment(topAlignment, mainAlignment, genomeName);
     }
 
     // Clear update flag if present, since the genome has just been updated.
@@ -152,6 +152,6 @@ int main(int argc, char *argv[]) {
     }
 
     if (!noMarkAncestors) {
-        markAncestorsForUpdate(mainAlignment.get(), genomeName);
+        markAncestorsForUpdate(mainAlignment, genomeName);
     }
 }

--- a/modify/halUpdateBranchLengths.cpp
+++ b/modify/halUpdateBranchLengths.cpp
@@ -11,7 +11,7 @@ static void initParser(CLParser &optionsParser) {
                                             " except for the branch lengths");
 }
 
-void updateBranches(Alignment *alignment, Genome *genome, stTree *newTree) {
+void updateBranches(AlignmentPtr alignment, Genome *genome, stTree *newTree) {
     if (genome->getNumChildren() == 0) {
         return;
     }
@@ -51,5 +51,5 @@ int main(int argc, char *argv[]) {
                                             WRITE_ACCESS | READ_ACCESS));
     stTree *newTree = stTree_parseNewickString(newickTree.c_str());
     // recursively update branches
-    updateBranches(alignment.get(), alignment->openGenome(alignment->getRootName()), newTree);
+    updateBranches(alignment, alignment->openGenome(alignment->getRootName()), newTree);
 }

--- a/modify/markAncestors.cpp
+++ b/modify/markAncestors.cpp
@@ -5,7 +5,7 @@ using namespace hal;
 
 // Mark that all nodes above this one (but not this one) need to be
 // updated.
-void markAncestorsForUpdate(Alignment *alignment, string node) {
+void markAncestorsForUpdate(AlignmentPtr alignment, string node) {
     Genome *parent = NULL;
     try {
         parent = alignment->openGenome(alignment->getParentName(node));

--- a/modify/markAncestors.h
+++ b/modify/markAncestors.h
@@ -2,7 +2,7 @@
 #define _MARK_ANCESTORS_H_
 using namespace hal;
 
-void markAncestorsForUpdate(Alignment *alignment, std::string node);
+void markAncestorsForUpdate(AlignmentPtr alignment, std::string node);
 #endif // _MARK_ANCESTORS_H_
 // Local Variables:
 // mode: c++

--- a/mutations/impl/halSummarizeMutations.cpp
+++ b/mutations/impl/halSummarizeMutations.cpp
@@ -50,7 +50,7 @@ void SummarizeMutations::printCsv(ostream &outStream) const {
     outStream << endl;
 }
 
-void SummarizeMutations::analyzeAlignment(const Alignment *alignment, hal_size_t gapThreshold, double nThreshold, bool justSubs,
+void SummarizeMutations::analyzeAlignmentPtr(AlignmentConstPtr alignment, hal_size_t gapThreshold, double nThreshold, bool justSubs,
                                           const set<string> *targetSet) {
     _gapThreshold = gapThreshold;
     _nThreshold = nThreshold;

--- a/mutations/impl/halSummarizeMutationsMain.cpp
+++ b/mutations/impl/halSummarizeMutationsMain.cpp
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
         }
 
         SummarizeMutations mutations;
-        mutations.analyzeAlignment(alignment.get(), maxGap, nThreshold, justSubs, targetSet.empty() ? NULL : &targetNames);
+        mutations.analyzeAlignmentPtr(alignment, maxGap, nThreshold, justSubs, targetSet.empty() ? NULL : &targetNames);
 
         cout << endl << mutations;
     } catch (hal_exception &e) {

--- a/mutations/inc/halSummarizeMutations.h
+++ b/mutations/inc/halSummarizeMutations.h
@@ -23,7 +23,7 @@ namespace hal {
         virtual ~SummarizeMutations();
 
         void printCsv(std::ostream &outStream) const;
-        void analyzeAlignment(const Alignment *alignment, hal_size_t gapThreshold, double nThreshold, bool justSubs,
+        void analyzeAlignmentPtr(AlignmentConstPtr alignment, hal_size_t gapThreshold, double nThreshold, bool justSubs,
                               const std::set<std::string> *targetSet = NULL);
 
       protected:
@@ -36,7 +36,7 @@ namespace hal {
         typedef std::map<StrPair, MutationsStats> BranchMap;
 
         BranchMap _branchMap;
-        const Alignment* _alignment;
+        AlignmentConstPtr _alignment;
         hal_size_t _gapThreshold;
         double _nThreshold;
         bool _justSubs;

--- a/randgen/halRandGen.cpp
+++ b/randgen/halRandGen.cpp
@@ -112,7 +112,7 @@ int main(int argc, char **argv) {
     try {
         AlignmentPtr alignment(openHalAlignment(options._halFile, &optionsParser, hal::CREATE_ACCESS));
         // call the crappy unit-test simulator
-        createRandomAlignment(rng, alignment.get(), options._meanDegree, options._maxBranchLength, options._minGenomes,
+        createRandomAlignment(rng, alignment, options._meanDegree, options._maxBranchLength, options._minGenomes,
                               options._maxGenomes, options._minSegmentLength, options._maxSegmentLength, options._minSegments,
                               options._maxSegments);
 

--- a/stats/impl/halStats.cpp
+++ b/stats/impl/halStats.cpp
@@ -15,8 +15,8 @@ using namespace hal;
 HalStats::HalStats() {
 }
 
-HalStats::HalStats(const Alignment *alignment) {
-    readAlignment(alignment);
+HalStats::HalStats(AlignmentConstPtr alignment) {
+    readAlignmentPtr(alignment);
 }
 
 HalStats::~HalStats() {
@@ -36,7 +36,7 @@ void HalStats::printCsv(ostream &outStream) const {
     outStream << endl;
 }
 
-void HalStats::readAlignment(const Alignment *alignment) {
+void HalStats::readAlignmentPtr(AlignmentConstPtr alignment) {
     _tree.clear();
     _genomeStatsVec.clear();
 
@@ -48,7 +48,7 @@ void HalStats::readAlignment(const Alignment *alignment) {
     }
 }
 
-void HalStats::readGenomeRecursive(const Alignment *alignment, const Genome *genome) {
+void HalStats::readGenomeRecursive(AlignmentConstPtr alignment, const Genome *genome) {
     assert(genome != NULL);
 
     GenomeStats genomeStats;

--- a/stats/impl/halStatsMain.cpp
+++ b/stats/impl/halStatsMain.cpp
@@ -13,26 +13,26 @@
 using namespace std;
 using namespace hal;
 
-static void printGenomes(ostream &os, const Alignment *alignment);
-static void printSequences(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printSequenceStats(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printBedSequenceStats(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printBranchPath(ostream &os, const Alignment *alignment, const vector<string> &genomeNames, bool keepRoot);
-static void printBranches(ostream &os, const Alignment *alignment);
-static void printChildren(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printParent(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printRootName(ostream &os, const Alignment *alignment);
-static void printBranchLength(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printBranches(ostream &os, const Alignment *alignment);
-static void printNumSegments(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printBaseComp(ostream &os, const Alignment *alignment, const string &baseCompPair);
-static void printGenomeMetaData(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printAlignmentMetaData(ostream &os, const Alignment *alignment);
-static void printChromSizes(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printPercentID(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printCoverage(ostream &os, const Alignment *alignment, const string &genomeName);
-static void printSegments(ostream &os, const Alignment *alignment, const string &genomeName, bool top);
-static void printAllCoverage(ostream &os, const Alignment *alignment);
+static void printGenomes(ostream &os, AlignmentConstPtr alignment);
+static void printSequences(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printSequenceStats(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printBedSequenceStats(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printBranchPath(ostream &os, AlignmentConstPtr alignment, const vector<string> &genomeNames, bool keepRoot);
+static void printBranches(ostream &os, AlignmentConstPtr alignment);
+static void printChildren(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printParent(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printRootName(ostream &os, AlignmentConstPtr alignment);
+static void printBranchLength(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printBranches(ostream &os, AlignmentConstPtr alignment);
+static void printNumSegments(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printBaseComp(ostream &os, AlignmentConstPtr alignment, const string &baseCompPair);
+static void printGenomeMetaData(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printAlignmentPtrMetaData(ostream &os, AlignmentConstPtr alignment);
+static void printChromSizes(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printPercentID(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printCoverage(ostream &os, AlignmentConstPtr alignment, const string &genomeName);
+static void printSegments(ostream &os, AlignmentConstPtr alignment, const string &genomeName, bool top);
+static void printAllCoverage(ostream &os, AlignmentConstPtr alignment);
 
 int main(int argc, char **argv) {
     CLParser optionsParser;
@@ -220,51 +220,51 @@ int main(int argc, char **argv) {
         AlignmentConstPtr alignment(openHalAlignment(path, &optionsParser));
         // FIXME: why are strings of '""' used for no value instead of empty strings.
         if (listGenomes == true && alignment->getNumGenomes() > 0) {
-            printGenomes(cout, alignment.get());
+            printGenomes(cout, alignment);
         } else if (sequencesFromGenome != "\"\"") {
-            printSequences(cout, alignment.get(), sequencesFromGenome);
+            printSequences(cout, alignment, sequencesFromGenome);
         } else if (tree == true) {
             cout << alignment->getNewickTree() << endl;
         } else if (sequenceStatsFromGenome != "\"\"") {
-            printSequenceStats(cout, alignment.get(), sequenceStatsFromGenome);
+            printSequenceStats(cout, alignment, sequenceStatsFromGenome);
         } else if (bedSequencesFromGenome != "\"\"") {
-            printBedSequenceStats(cout, alignment.get(), bedSequencesFromGenome);
+            printBedSequenceStats(cout, alignment, bedSequencesFromGenome);
         } else if (spanGenomes != "\"\"") {
-            printBranchPath(cout, alignment.get(), chopString(spanGenomes, ","), false);
+            printBranchPath(cout, alignment, chopString(spanGenomes, ","), false);
         } else if (spanRootGenomes != "\"\"") {
-            printBranchPath(cout, alignment.get(), chopString(spanRootGenomes, ","), true);
+            printBranchPath(cout, alignment, chopString(spanRootGenomes, ","), true);
         } else if (branches == true) {
-            printBranches(cout, alignment.get());
+            printBranches(cout, alignment);
         } else if (childrenFromGenome != "\"\"") {
-            printChildren(cout, alignment.get(), childrenFromGenome);
+            printChildren(cout, alignment, childrenFromGenome);
         } else if (parentFromGenome != "\"\"") {
-            printParent(cout, alignment.get(), parentFromGenome);
+            printParent(cout, alignment, parentFromGenome);
         } else if (printRoot == true) {
-            printRootName(cout, alignment.get());
+            printRootName(cout, alignment);
         } else if (nameForBL != "\"\"") {
-            printBranchLength(cout, alignment.get(), nameForBL);
+            printBranchLength(cout, alignment, nameForBL);
         } else if (numSegmentsGenome != "\"\"") {
-            printNumSegments(cout, alignment.get(), numSegmentsGenome);
+            printNumSegments(cout, alignment, numSegmentsGenome);
         } else if (baseCompPair != "\"\"") {
-            printBaseComp(cout, alignment.get(), baseCompPair);
+            printBaseComp(cout, alignment, baseCompPair);
         } else if (genomeMetaData != "\"\"") {
-            printGenomeMetaData(cout, alignment.get(), genomeMetaData);
+            printGenomeMetaData(cout, alignment, genomeMetaData);
         } else if (chromSizesFromGenome != "\"\"") {
-            printChromSizes(cout, alignment.get(), chromSizesFromGenome);
+            printChromSizes(cout, alignment, chromSizesFromGenome);
         } else if (percentID != "\"\"") {
-            printPercentID(cout, alignment.get(), percentID);
+            printPercentID(cout, alignment, percentID);
         } else if (coverage != "\"\"") {
-            printCoverage(cout, alignment.get(), coverage);
+            printCoverage(cout, alignment, coverage);
         } else if (topSegments != "\"\"") {
-            printSegments(cout, alignment.get(), topSegments, true);
+            printSegments(cout, alignment, topSegments, true);
         } else if (bottomSegments != "\"\"") {
-            printSegments(cout, alignment.get(), bottomSegments, false);
+            printSegments(cout, alignment, bottomSegments, false);
         } else if (allCoverage) {
-            printAllCoverage(cout, alignment.get());
+            printAllCoverage(cout, alignment);
         } else if (metaData) {
-            printAlignmentMetaData(cout, alignment.get());
+            printAlignmentPtrMetaData(cout, alignment);
         } else {
-            HalStats halStats(alignment.get());
+            HalStats halStats(alignment);
             cout << endl << "hal v" << alignment->getVersion() << "\n" << halStats;
         }
     } catch (hal_exception &e) {
@@ -278,7 +278,7 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-void printGenomes(ostream &os, const Alignment *alignment) {
+void printGenomes(ostream &os, AlignmentConstPtr alignment) {
     const Genome *root = alignment->openGenome(alignment->getRootName());
     set<const Genome *> genomes;
     getGenomesInSubTree(root, genomes);
@@ -294,7 +294,7 @@ void printGenomes(ostream &os, const Alignment *alignment) {
     os << endl;
 }
 
-void printSequences(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printSequences(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
     if (genome->getNumSequences() > 0) {
         for (SequenceIteratorPtr seqIt = genome->getSequenceIterator(); not seqIt->atEnd(); seqIt->toNext()) {
@@ -307,7 +307,7 @@ void printSequences(ostream &os, const Alignment *alignment, const string &genom
     os << endl;
 }
 
-void printSequenceStats(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printSequenceStats(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
     if (genome->getNumSequences() > 0) {
         os << "SequenceName, Length, NumTopSegments, NumBottomSegments" << endl;
@@ -320,7 +320,7 @@ void printSequenceStats(ostream &os, const Alignment *alignment, const string &g
     os << endl;
 }
 
-void printBedSequenceStats(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printBedSequenceStats(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
     if (genome->getNumSequences() > 0) {
         for (SequenceIteratorPtr seqIt = genome->getSequenceIterator(); not seqIt->atEnd(); seqIt->toNext()) {
@@ -329,7 +329,7 @@ void printBedSequenceStats(ostream &os, const Alignment *alignment, const string
     }
 }
 
-static void printBranchPath(ostream &os, const Alignment *alignment, const vector<string> &genomeNames, bool keepRoot) {
+static void printBranchPath(ostream &os, AlignmentConstPtr alignment, const vector<string> &genomeNames, bool keepRoot) {
     set<const Genome *> inputSet;
     for (size_t i = 0; i < genomeNames.size(); ++i) {
         const Genome *genome = alignment->openGenome(genomeNames[i]);
@@ -377,7 +377,7 @@ static void printBranchPath(ostream &os, const Alignment *alignment, const vecto
     os << endl;
 }
 
-static void printBranches(ostream &os, const Alignment *alignment) {
+static void printBranches(ostream &os, AlignmentConstPtr alignment) {
     const Genome *root = alignment->openGenome(alignment->getRootName());
     set<const Genome *> genomes;
     getGenomesInSubTree(root, genomes);
@@ -396,7 +396,7 @@ static void printBranches(ostream &os, const Alignment *alignment) {
     os << endl;
 }
 
-void printChildren(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printChildren(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     vector<string> children = alignment->getChildNames(genomeName);
     for (size_t i = 0; i < children.size(); ++i) {
         os << children[i];
@@ -407,29 +407,29 @@ void printChildren(ostream &os, const Alignment *alignment, const string &genome
     os << endl;
 }
 
-void printParent(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printParent(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     if (genomeName != alignment->getRootName()) {
         os << alignment->getParentName(genomeName) << endl;
     }
 }
 
-void printRootName(ostream &os, const Alignment *alignment) {
+void printRootName(ostream &os, AlignmentConstPtr alignment) {
     os << alignment->getRootName() << endl;
 }
 
-void printBranchLength(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printBranchLength(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     if (genomeName != alignment->getRootName()) {
         string parentName = alignment->getParentName(genomeName);
         os << alignment->getBranchLength(parentName, genomeName) << endl;
     }
 }
 
-void printNumSegments(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printNumSegments(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
     os << genome->getNumTopSegments() << " " << genome->getNumBottomSegments() << endl;
 }
 
-void printBaseComp(ostream &os, const Alignment *alignment, const string &baseCompPair) {
+void printBaseComp(ostream &os, AlignmentConstPtr alignment, const string &baseCompPair) {
     string genomeName;
     hal_size_t step = 0;
     vector<string> tokens = chopString(baseCompPair, ",");
@@ -483,7 +483,7 @@ void printBaseComp(ostream &os, const Alignment *alignment, const string &baseCo
        << '\n';
 }
 
-void printGenomeMetaData(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printGenomeMetaData(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
     const MetaData *metaData = genome->getMetaData();
     const map<string, string> metaDataMap = metaData->getMap();
@@ -494,7 +494,7 @@ void printGenomeMetaData(ostream &os, const Alignment *alignment, const string &
     alignment->closeGenome(genome);
 }
 
-void printAlignmentMetaData(ostream &os, const Alignment *alignment) {
+void printAlignmentPtrMetaData(ostream &os, AlignmentConstPtr alignment) {
     const MetaData *metaData = alignment->getMetaData();
     const map<string, string> metaDataMap = metaData->getMap();
     map<string, string>::const_iterator mapIt = metaDataMap.begin();
@@ -503,7 +503,7 @@ void printAlignmentMetaData(ostream &os, const Alignment *alignment) {
     }
 }
 
-void printChromSizes(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printChromSizes(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
     if (genome->getNumSequences() > 0) {
 
@@ -513,7 +513,7 @@ void printChromSizes(ostream &os, const Alignment *alignment, const string &geno
     }
 }
 
-void printPercentID(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printPercentID(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *refGenome = alignment->openGenome(genomeName);
 
     ColumnIteratorPtr colIt = refGenome->getColumnIterator();
@@ -611,7 +611,7 @@ void printPercentID(ostream &os, const Alignment *alignment, const string &genom
     }
 }
 
-void printCoverage(ostream &os, const Alignment *alignment, const string &genomeName) {
+void printCoverage(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *refGenome = alignment->openGenome(genomeName);
 
     ColumnIteratorPtr colIt = refGenome->getColumnIterator(NULL, 0, 0, NULL_INDEX, false, false, false, true);
@@ -691,7 +691,7 @@ void printCoverage(ostream &os, const Alignment *alignment, const string &genome
     }
 }
 
-static void printSegments(ostream &os, const Alignment *alignment, const string &genomeName, bool top) {
+static void printSegments(ostream &os, AlignmentConstPtr alignment, const string &genomeName, bool top) {
     const Genome *genome = alignment->openGenome(genomeName);
     hal_size_t numSegments = 0;
     SegmentIteratorPtr segment;
@@ -715,8 +715,8 @@ static void printSegments(ostream &os, const Alignment *alignment, const string 
 }
 
 // Print coverage for all leaves vs. all leaves efficiently.
-static void printAllCoverage(ostream &os, const Alignment *alignment) {
-    vector<const Genome *> leafGenomes = getLeafGenomes(alignment);
+static void printAllCoverage(ostream &os, AlignmentConstPtr alignment) {
+    vector<const Genome *> leafGenomes = getLeafGenomes(alignment.get());
     ColumnIterator::VisitCache visitCache;
     map<pair<const Genome *, const Genome *>, vector<hal_size_t> *> histograms;
     for (hal_size_t i = 0; i < leafGenomes.size(); i++) {

--- a/stats/inc/halStats.h
+++ b/stats/inc/halStats.h
@@ -23,14 +23,14 @@ namespace hal {
     class HalStats {
       public:
         HalStats();
-        HalStats(const Alignment *alignment);
+        HalStats(AlignmentConstPtr alignment);
         virtual ~HalStats();
 
         void printCsv(std::ostream &outStream) const;
-        void readAlignment(const Alignment *alignment);
+        void readAlignmentPtr(AlignmentConstPtr alignment);
 
       protected:
-        void readGenomeRecursive(const Alignment *alignment, const Genome *genome);
+        void readGenomeRecursive(AlignmentConstPtr alignment, const Genome *genome);
 
         std::string _tree;
         std::vector<GenomeStats> _genomeStatsVec;

--- a/synteny/impl/hal2psl.cpp
+++ b/synteny/impl/hal2psl.cpp
@@ -17,7 +17,7 @@ void Hal2Psl::storePslResults(std::vector<PslBlock> &pslBlocks) {
         makeUpPsl(i->_psl, i->_blocks, i->_strand, i->_start, i->_chrName, pslBlocks);
     }
 }
-std::vector<PslBlock> Hal2Psl::convert2psl(const Alignment *alignment, const Genome *srcGenome, const Genome *tgtGenome,
+std::vector<PslBlock> Hal2Psl::convert2psl(AlignmentConstPtr alignment, const Genome *srcGenome, const Genome *tgtGenome,
                                            const std::string srcChrom) {
 
     std::vector<PslBlock> pslBlocks;

--- a/synteny/impl/halSynteny.cpp
+++ b/synteny/impl/halSynteny.cpp
@@ -25,14 +25,14 @@ static void initParser(CLParser &optionsParser) {
     optionsParser.setDescription("Convert alignments into synteny blocks");
 }
 
-const Genome *openGenomeOrThrow(const Alignment *alignment, const std::string &genomeName) {
+const Genome *openGenomeOrThrow(AlignmentConstPtr alignment, const std::string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
     return genome;
 }
 
-const Alignment *openAlignmentOrThrow(const std::string &alignmentFile, const CLParser &optionsParser) {
+AlignmentConstPtr openAlignmentOrThrow(const std::string &alignmentFile, const CLParser &optionsParser) {
 
-    auto alignment = openHalAlignment(alignmentFile, &optionsParser);
+    AlignmentConstPtr alignment(openHalAlignment(alignmentFile, &optionsParser));
     if (alignment->getNumGenomes() == 0) {
         throw hal_exception("hal alignment is empty");
     }
@@ -78,7 +78,7 @@ static std::vector<std::string> getChromNames(const Genome *genome) {
     return chromNames;
 }
 
-static void syntenyBlockForChrom(const Alignment *alignment,
+static void syntenyBlockForChrom(AlignmentConstPtr alignment,
                                  const Genome *targetGenome, const Genome *queryGenome,
                                  std::string queryChromosome, hal_size_t minBlockSize,
                                  hal_size_t maxAnchorDistance, std::ofstream &pslFh) {
@@ -89,7 +89,7 @@ static void syntenyBlockForChrom(const Alignment *alignment,
 
 
 /* do one chromosome at a time to reduce memory */
-static void syntenyFromHal(const Alignment *alignment, std::string queryGenomeName,
+static void syntenyFromHal(AlignmentConstPtr alignment, std::string queryGenomeName,
                            std::string targetGenomeName, std::string queryChromosome,
                            hal_size_t minBlockSize, hal_size_t maxAnchorDistance, std::string outPslPath) {
     auto targetGenome = alignment->openGenome(targetGenomeName);

--- a/synteny/inc/hal2psl.h
+++ b/synteny/inc/hal2psl.h
@@ -28,7 +28,7 @@ namespace hal {
       public:
         Hal2Psl() {
         }
-        std::vector<PslBlock> convert2psl(const Alignment *alignment, const Genome *srcGenome, const Genome *tgtGenome,
+        std::vector<PslBlock> convert2psl(AlignmentConstPtr alignment, const Genome *srcGenome, const Genome *tgtGenome,
                                           const std::string srcChrom);
     };
 }


### PR DESCRIPTION
HAL originally used smart pointers to pass alignment objects around.  Then [this commit](https://github.com/ComparativeGenomicsToolkit/hal/commit/992e6dcfa2c0b420ce472cd879381620e7112fcf#diff-1a10322af3926720345782ac44d30896) changed some functions to use normal pointers instead.  

The problem is that it created at least two instances of AlignmentPtr.get() -> Alignment* -> AlignmentPtr, that lead to double free segfaults.  One in `halSummarizeMutations` (#102), and one in `halLodExtract` (#143).  I suspect there are others.   

I appreciate that `const Alignment*` might look cleaner than `AlignmentConstPtr` but there are few Alignment objects, so practically speaking I cannot imagine any kind of real effect of passing Aligments by smart pointer or not.  The above issues make me think this sort of refactoring is more trouble than it's worth, so this PR reverts back to using the smart pointers, as it seems safer and easier to do by grep than fixing the current scheme of mixing normal and smart pointers.  

I didn't touch the `/api` interface, so I'm hoping this doesn't break anyone's code too much who's building against hal. (liftover api is reverted to use the smart pointers tho)   

resolves #143