### PR TITLE
Revert semantic change to Alignment::openGenome

### DIFF
--- a/alignmentDepth/halAlignmentDepth.cpp
+++ b/alignmentDepth/halAlignmentDepth.cpp
@@ -141,6 +141,9 @@ int main(int argc, char **argv) {
         const Genome *rootGenome = NULL;
         if (rootGenomeName != "\"\"") {
             rootGenome = alignment->openGenome(rootGenomeName);
+            if (rootGenome == NULL) {
+                throw hal_exception(string("Root genome, ") + rootGenomeName + ", not found in alignment");
+            }
             if (rootGenomeName != alignment->getRootName()) {
                 getGenomesInSubTree(rootGenome, targetSet);
             }
@@ -150,6 +153,9 @@ int main(int argc, char **argv) {
             vector<string> targetNames = chopString(targetGenomes, ",");
             for (size_t i = 0; i < targetNames.size(); ++i) {
                 const Genome *tgtGenome = alignment->openGenome(targetNames[i]);
+                if (tgtGenome == NULL) {
+                    throw hal_exception(string("Target genome, ") + targetNames[i] + ", not found in alignment");
+                }
                 targetSet.insert(tgtGenome);
             }
         }
@@ -158,6 +164,9 @@ int main(int argc, char **argv) {
         const Genome *refGenome = NULL;
         if (refGenomeName != "\"\"") {
             refGenome = alignment->openGenome(refGenomeName);
+            if (refGenome == NULL) {
+                throw hal_exception(string("Reference genome, ") + refGenomeName + ", not found in alignment");
+            }
         } else {
             refGenome = alignment->openGenome(alignment->getRootName());
         }

--- a/api/hdf5_impl/hdf5Alignment.cpp
+++ b/api/hdf5_impl/hdf5Alignment.cpp
@@ -433,9 +433,6 @@ Genome *Hdf5Alignment::openGenome(const string &name) {
         genome = new Hdf5Genome(name, this, _file, _dcprops, _inMemory);
         _openGenomes.insert(pair<string, Hdf5Genome *>(name, genome));
     }
-    if (genome == NULL) {
-        throw GenomeNotFoundException(name);
-    }
     return genome;
 }
 

--- a/api/impl/halCommon.cpp
+++ b/api/impl/halCommon.cpp
@@ -200,6 +200,7 @@ vector<const Genome *> hal::getLeafGenomes(const Alignment *alignment) {
     vector<const Genome *> leafGenomes;
     for (hal_size_t i = 0; i < leafNames.size(); i++) {
         const Genome *genome = alignment->openGenome(leafNames[i]);
+        assert(genome != NULL);
         leafGenomes.push_back(genome);
     }
     return leafGenomes;

--- a/api/impl/halValidate.cpp
+++ b/api/impl/halValidate.cpp
@@ -311,6 +311,9 @@ void hal::validateAlignment(const Alignment *alignment) {
         bfQueue.pop_back();
         if (name.empty() == false) {
             const Genome *genome = alignment->openGenome(name);
+            if (genome == NULL) {
+                throw hal_exception("Failure to open genome " + name);
+            }
             validateGenome(genome);
             vector<string> childNames = alignment->getChildNames(name);
             for (size_t i = 0; i < childNames.size(); ++i) {

--- a/api/inc/halAlignment.h
+++ b/api/inc/halAlignment.h
@@ -13,14 +13,7 @@
 #include <vector>
 
 namespace hal {
-    /* thrown when alignment not found */
-    class GenomeNotFoundException: public hal_exception {
-        public:
-        GenomeNotFoundException(const std::string &name):
-            hal_exception("Genome not found: " + name) {
-        }
-    };
-    
+
     /**
      * Interface for a hierarhcical alignment.  Responsible for creating
      * and accessing genomes and tree information.  Accesssing a HAL file must
@@ -72,14 +65,11 @@ namespace hal {
 
         /** Open an exsting genome for reading
          * @param name Name of genome to open
-         * @throws GenomeNotFoundException
-         * DO NOT DELETE THE RETURNED OBJECT, USE closeGenome()
-         */
+         * DO NOT DELETE THE RETURNED OBJECT, USE closeGenome() */
         virtual const Genome *openGenome(const std::string &name) const = 0;
 
         /** Open an existing genome for reading and updating
          * @param name Name of genome to open.
-         * @throws GenomeNotFoundException
          * DO NOT DELETE THE RETURNED OBJECT, USE closeGenome() */
         virtual Genome *openGenome(const std::string &name) = 0;
 

--- a/api/mmap_impl/mmapAlignment.cpp
+++ b/api/mmap_impl/mmapAlignment.cpp
@@ -166,17 +166,17 @@ Genome *MMapAlignment::_openGenome(const string &name) const {
         return _openGenomes[name];
     }
     if (_genomeNameHash == NULL) {
-        throw GenomeNotFoundException(name);
+        return NULL;
     }
     hal_index_t genomeIndex = _genomeNameHash->getIndex(name);
     if (genomeIndex == NULL_INDEX) {
-        throw GenomeNotFoundException(name);
+        return NULL;
     }
     // FIXME: put this in a function
     MMapGenomeData *genomeDataArray =
         (MMapGenomeData *)resolveOffset(_data->_genomeArrayOffset, _data->_numGenomes * sizeof(MMapGenomeData));
     if (genomeDataArray[genomeIndex].getName(const_cast<MMapAlignment *>(this)) != name) {
-        throw GenomeNotFoundException(name); // name not in perfect hash
+        return NULL; // name not in perfect hash
     }
     MMapGenome *genome = new MMapGenome(const_cast<MMapAlignment *>(this), &genomeDataArray[genomeIndex], genomeIndex);
     _openGenomes[name] = genome;

--- a/api/tests/halGenomeTest.cpp
+++ b/api/tests/halGenomeTest.cpp
@@ -70,12 +70,8 @@ struct GenomeCreateTest : public AlignmentTest {
         leaf3Genome->setDimensions(seqVec);
     }
 
-    void checkCallBack(AlignmentConstPtr alignment) {
-        const Genome *dudGenome = NULL;
-        try {
-            dudGenome = alignment->openGenome("Zebra");
-        } catch (const GenomeNotFoundException& ex) {
-        }
+    void checkCallBack(const Alignment *alignment) {
+        const Genome *dudGenome = alignment->openGenome("Zebra");
         CuAssertTrue(_testCase, dudGenome == NULL);
         const Genome *ancGenome = alignment->openGenome("AncGenome");
         const MetaData *ancMeta = ancGenome->getMetaData();

--- a/blockViz/impl/hal2chain.cpp
+++ b/blockViz/impl/hal2chain.cpp
@@ -69,6 +69,9 @@ int main(int argc, char **argv) {
         AlignmentConstPtr alignment(openHalAlignment(halPath, &optionsParser));
 
         const Genome *genome = alignment->openGenome(genomeName);
+        if (genome == NULL) {
+            throw hal_exception(string("Genome not found: ") + genomeName);
+        }
         hal_index_t endPosition = length > 0 ? start + length : genome->getSequenceLength();
 
         const Sequence *sequence = NULL;

--- a/blockViz/impl/halBlockViz.cpp
+++ b/blockViz/impl/halBlockViz.cpp
@@ -568,10 +568,8 @@ extern "C" struct hal_chromosome_t *halGetChroms(int halHandle, char *speciesNam
         // read the lowest level of detail because it's fastest
         AlignmentConstPtr alignment = getExistingAlignment(halHandle, numeric_limits<hal_size_t>::max(), false);
 
-        const Genome *genome = NULL;
-        try {
-            genome = alignment->openGenome(speciesName);
-        } catch (const GenomeNotFoundException& ex) {
+        const Genome *genome = alignment->openGenome(speciesName);
+        if (genome == NULL) {
             halUnlock();
             handleError("halGetChroms: species with name " + string(speciesName) + " not found in alignment with handle " +
                             std::to_string(halHandle),
@@ -615,13 +613,11 @@ extern "C" char *halGetDna(int halHandle, char *speciesName, char *chromName, ha
     char *dna = NULL;
     try {
         AlignmentConstPtr alignment = getExistingAlignment(halHandle, 0, true);
-        const Genome *genome = NULL;
-        try {
-            genome = alignment->openGenome(speciesName);
-        } catch (const GenomeNotFoundException& ex) {
+        const Genome *genome = alignment->openGenome(speciesName);
+        if (genome == NULL) {
             halUnlock();
             handleError("halGetChroms: species with name " + string(speciesName) + " not found in alignment with handle " +
-                            std::to_string(halHandle),
+                        std::to_string(halHandle),
                         errStr);
             return NULL;
         }
@@ -695,8 +691,17 @@ static void checkHandle(int handle) {
 
 static void checkGenomes(int halHandle, AlignmentConstPtr alignment, const string &qSpecies, const string &tSpecies,
                          const string &tChrom) {
-    alignment->closeGenome(alignment->openGenome(qSpecies)); // check for existance
+    const Genome *qGenome = alignment->openGenome(qSpecies);
+    if (qGenome == NULL) {
+        throw hal_exception("Query species " + qSpecies + " not found in alignment with " + "handle " +
+                            std::to_string(halHandle));
+    }
     const Genome *tGenome = alignment->openGenome(tSpecies);
+    if (tGenome == NULL) {
+        throw hal_exception("Reference species " + tSpecies + " not found in alignment with " + "handle " +
+                            std::to_string(halHandle));
+    }
+
     const Sequence *tSequence = tGenome->getSequence(tChrom);
     if (tSequence == NULL) {
         throw hal_exception("Unable to locate sequence " + tChrom + " in genome " + tSpecies);
@@ -743,6 +748,9 @@ static hal_block_results_t *readBlocks(AlignmentConstPtr seqAlignment, const Seq
 
         if (coalescenceLimitName != NULL) {
             coalescenceLimit = alignment->openGenome(coalescenceLimitName);
+            if (coalescenceLimit == NULL) {
+                throw hal_exception("Could not find coalescence limit " + string(coalescenceLimitName) + " in alignment");
+            }
         }
 
         blockMapper.init(tGenome, qGenome, absStart, absEnd, tReversed, doDupes, 0, doAdjes, coalescenceLimit);
@@ -831,12 +839,19 @@ static void readBlock(AlignmentConstPtr seqAlignment, hal_block_t *cur, vector<M
     cur->qSequence = NULL;
     if (getSequenceString != 0) {
         const Genome *qSeqGenome = seqAlignment->openGenome(qSequence->getGenome()->getName());
+        if (qSeqGenome == NULL) {
+            throw hal_exception("Unable to open genome " + qSequence->getGenome()->getName() + " for DNA sequence extraction");
+        }
         const Sequence *qSeqSequence = qSeqGenome->getSequence(qSequence->getName());
         if (qSeqSequence == NULL) {
             throw hal_exception("Unable to open sequence " + qSequence->getName() + " for DNA sequence extraction");
         }
 
         const Genome *tSeqGenome = seqAlignment->openGenome(tSequence->getGenome()->getName());
+        if (tSeqGenome == NULL) {
+            throw hal_exception("Unable to open genome " + tSequence->getGenome()->getName() + " for DNA sequence extraction");
+        }
+
         const Sequence *tSeqSequence = tSeqGenome->getSequence(tSequence->getName());
         if (tSeqSequence == NULL) {
             throw hal_exception("Unable to open sequence " + tSequence->getName() + " for DNA sequence extraction");
@@ -1083,6 +1098,9 @@ extern "C" struct hal_metadata_t *halGetGenomeMetadata(int halHandle, const char
         AlignmentConstPtr alignment = getExistingAlignment(halHandle, numeric_limits<hal_size_t>::max(), false);
 
         const Genome *genome = alignment->openGenome(genomeName);
+        if (genome == NULL) {
+            throw hal_exception("Genome " + string(genomeName) + " not found in alignment");
+        }
         const MetaData *metaData = genome->getMetaData();
         const map<string, string> metaDataMap = metaData->getMap();
 

--- a/extract/impl/hal4dExtractMain.cpp
+++ b/extract/impl/hal4dExtractMain.cpp
@@ -60,6 +60,11 @@ int main(int argc, char **argv) {
         }
 
         const Genome *genome = inAlignment->openGenome(genomeName);
+
+        if (genome == NULL) {
+            throw hal_exception(string("Unable to open genome ") + genomeName + "in alignment.");
+        }
+
         ifstream inBedFileStream;
         istream *inBedStream;
         if (inBedPath == "stdin") {

--- a/extract/impl/halAlignedExtract.cpp
+++ b/extract/impl/halAlignedExtract.cpp
@@ -61,6 +61,10 @@ int main(int argc, char **argv) {
         }
 
         const Genome *genome = inAlignment->openGenome(genomeName);
+
+        if (genome == NULL) {
+            throw hal_exception(string("Unable to open genome ") + genomeName + "in alignment.");
+        }
         if (genome->getParent() != NULL) {
             ostream *bedStream = &cout;
             if (outBedPath != "stdout") {

--- a/extract/impl/halExtract.cpp
+++ b/extract/impl/halExtract.cpp
@@ -145,6 +145,9 @@ void copyGenome(const Genome *inGenome, Genome *outGenome) {
 
 static void extractTree(AlignmentConstPtr inAlignment, AlignmentPtr outAlignment, const string &rootName) {
     const Genome *genome = inAlignment->openGenome(rootName);
+    if (genome == NULL) {
+        throw hal_exception(string("Genome not found: ") + rootName);
+    }
     Genome *newGenome = NULL;
     if (outAlignment->getNumGenomes() == 0 || genome->getParent() == NULL) {
         newGenome = outAlignment->addRootGenome(rootName);

--- a/extract/impl/halMaskExtractMain.cpp
+++ b/extract/impl/halMaskExtractMain.cpp
@@ -52,6 +52,10 @@ int main(int argc, char **argv) {
         AlignmentConstPtr alignment(openHalAlignment(halPath, &optionsParser));
 
         const Genome *genome = alignment->openGenome(genomeName);
+        if (genome == NULL) {
+            throw hal_exception(string("Genome ") + genomeName + " not found.");
+        }
+
         ostream *bedStream = &cout;
         bool newBed = false;
         if (bedPath != "stdout") {

--- a/fasta/hal2fasta.cpp
+++ b/fasta/hal2fasta.cpp
@@ -114,6 +114,10 @@ int main(int argc, char **argv) {
             bfsQueue.pop_front();
 
             const Genome *genome = alignment->openGenome(curName);
+            if (genome == NULL) {
+                throw hal_exception(string("Genome ") + curName + " not found");
+            }
+
             const Sequence *sequence = NULL;
             if (sequenceName != "\"\"") {
                 sequence = genome->getSequence(sequenceName);

--- a/liftover/impl/halLiftoverMain.cpp
+++ b/liftover/impl/halLiftoverMain.cpp
@@ -94,11 +94,20 @@ int main(int argc, char **argv) {
         }
 
         const Genome *srcGenome = alignment->openGenome(srcGenomeName);
+        if (srcGenome == NULL) {
+            throw hal_exception(string("srcGenome, ") + srcGenomeName + ", not found in alignment");
+        }
         const Genome *tgtGenome = alignment->openGenome(tgtGenomeName);
+        if (tgtGenome == NULL) {
+            throw hal_exception(string("tgtGenome, ") + tgtGenomeName + ", not found in alignment");
+        }
 
         const Genome *coalescenceLimit = NULL;
         if (coalescenceLimitName != "") {
             coalescenceLimit = alignment->openGenome(coalescenceLimitName);
+            if (coalescenceLimit == NULL) {
+                throw hal_exception("coalescence limit genome " + coalescenceLimitName + " not found in alignment\n");
+            }
         }
 
         ifstream srcBed;

--- a/liftover/impl/halWiggleLiftoverMain.cpp
+++ b/liftover/impl/halWiggleLiftoverMain.cpp
@@ -78,7 +78,13 @@ int main(int argc, char **argv) {
         }
 
         const Genome *srcGenome = alignment->openGenome(srcGenomeName);
+        if (srcGenome == NULL) {
+            throw hal_exception(string("srcGenome, ") + srcGenomeName + ", not found in alignment");
+        }
         const Genome *tgtGenome = alignment->openGenome(tgtGenomeName);
+        if (tgtGenome == NULL) {
+            throw hal_exception(string("tgtGenome, ") + tgtGenomeName + ", not found in alignment");
+        }
 
         ifstream srcWig;
         istream *srcWigPtr;

--- a/lod/impl/halLodExtract.cpp
+++ b/lod/impl/halLodExtract.cpp
@@ -88,7 +88,12 @@ void LodExtract::createTree(const string &tree, const string &rootName) {
         if (label == NULL) {
             throw hal_exception("Error parsing tree: unlabeled node");
         }
-        _inAlignment->closeGenome(_inAlignment->openGenome(label)); // check for genome
+        const Genome *test = _inAlignment->openGenome(label);
+        if (test == NULL) {
+            throw hal_exception(string("Genome in tree: ") + string(label) + "doesn't exist in source alignment");
+        } else {
+            _inAlignment->closeGenome(test);
+        }
         if (node == root) {
             _outAlignment->addRootGenome(label);
         } else {
@@ -116,6 +121,7 @@ void LodExtract::createTree(const string &tree, const string &rootName) {
 
 void LodExtract::convertInternalNode(const string &genomeName, double scale) {
     const Genome *parent = _inAlignment->openGenome(genomeName);
+    assert(parent != NULL);
     vector<string> childNames = _outAlignment->getChildNames(genomeName);
     vector<const Genome *> children;
     for (hal_size_t i = 0; i < childNames.size(); ++i) {
@@ -247,7 +253,8 @@ void LodExtract::writeSequences(const Genome *inParent, const vector<const Genom
     vector<const Genome *> inGenomes = inChildren;
     inGenomes.push_back(inParent);
     const Genome *outParent = _outAlignment->openGenome(inParent->getName());
-    assert(outParent->getNumBottomSegments() > 0);
+    (void)outParent;
+    assert(outParent != NULL && outParent->getNumBottomSegments() > 0);
     string buffer;
 
     for (hal_size_t i = 0; i < inGenomes.size(); ++i) {
@@ -271,7 +278,7 @@ void LodExtract::writeSegments(const Genome *inParent, const vector<const Genome
     vector<const Genome *> inGenomes = inChildren;
     inGenomes.push_back(inParent);
     const Genome *outParent = _outAlignment->openGenome(inParent->getName());
-    assert(outParent->getNumBottomSegments() > 0);
+    assert(outParent != NULL && outParent->getNumBottomSegments() > 0);
     BottomSegmentIteratorPtr bottom;
     TopSegmentIteratorPtr top;
     SegmentIteratorPtr outSegment;
@@ -344,7 +351,7 @@ void LodExtract::writeHomologies(const Genome *inParent, const vector<const Geno
     vector<const Genome *> inGenomes = inChildren;
     inGenomes.push_back(inParent);
     Genome *outParent = _outAlignment->openGenome(inParent->getName());
-    assert(outParent->getNumBottomSegments() > 0);
+    assert(outParent != NULL && outParent->getNumBottomSegments() > 0);
     assert(inChildren.size() > 0);
     Genome *outChild = _outAlignment->openGenome(inChildren[0]->getName());
     BottomSegmentIteratorPtr bottom = outParent->getBottomSegmentIterator();

--- a/lod/impl/halLodExtractMain.cpp
+++ b/lod/impl/halLodExtractMain.cpp
@@ -89,8 +89,8 @@ int main(int argc, char **argv) {
         if (outAlignment->getNumGenomes() != 0) {
             throw hal_exception("Output hal Alignmnent cannot be initialized");
         }
-        if (rootName != "\"\"") {
-            inAlignment->openGenome(rootName); // check alignment exists
+        if (rootName != "\"\"" && inAlignment->openGenome(rootName) == NULL) {
+            throw hal_exception(string("Genome ") + rootName + " not found");
         }
         if (rootName == "\"\"") {
             rootName = "";

--- a/maf/Makefile
+++ b/maf/Makefile
@@ -78,6 +78,9 @@ output/small.hdf5.hal:
 	@mkdir -p output
 	../bin/halRandGen --preset small --seed 0 --testRand --format hdf5 output/small.hdf5.hal
 
+../bin/halRandGen:
+	cd ../randgen && ${MAKE}
+
 ${binDir}/%.py: %.py
 	@mkdir -p $(dir $@)
 	cp -f $< $@

--- a/maf/impl/hal2maf.cpp
+++ b/maf/impl/hal2maf.cpp
@@ -123,6 +123,9 @@ static void hal2maf(AlignmentConstPtr alignment, const MafOptions &opts) {
     set<const Genome *> targetSet;
     if (opts.rootGenomeName != "") {
         rootGenome = alignment->openGenome(opts.rootGenomeName);
+        if (rootGenome == NULL) {
+            throw hal_exception("Root genome " + opts.rootGenomeName + ", not found in alignment");
+        }
         if (opts.rootGenomeName != alignment->getRootName()) {
             getGenomesInSubTree(rootGenome, targetSet);
         }
@@ -132,6 +135,9 @@ static void hal2maf(AlignmentConstPtr alignment, const MafOptions &opts) {
         vector<string> targetNames = chopString(opts.targetGenomes, ",");
         for (size_t i = 0; i < targetNames.size(); ++i) {
             const Genome *tgtGenome = alignment->openGenome(targetNames[i]);
+            if (tgtGenome == NULL) {
+                throw hal_exception(string("Target genome, ") + targetNames[i] + ", not found in alignment");
+            }
             targetSet.insert(tgtGenome);
         }
     }
@@ -139,6 +145,9 @@ static void hal2maf(AlignmentConstPtr alignment, const MafOptions &opts) {
     const Genome *refGenome = NULL;
     if (opts.refGenomeName != "") {
         refGenome = alignment->openGenome(opts.refGenomeName);
+        if (refGenome == NULL) {
+            throw hal_exception("Reference genome, " + opts.refGenomeName + ", not found in alignment");
+        }
     } else {
         refGenome = alignment->openGenome(alignment->getRootName());
     }

--- a/maf/impl/halMafWriteGenomes.cpp
+++ b/maf/impl/halMafWriteGenomes.cpp
@@ -131,6 +131,7 @@ void MafWriteGenomes::createGenomes() {
                     Sequence::Info(sequenceName(i->first), i->second->_length, i->second->_numSegments, 0));
             }
             Genome *childGenome = _alignment->openGenome(childName);
+            assert(childGenome != NULL);
 
             childGenome->setDimensions(genomeDimensions);
             if (_topSegment == NULL && childGenome->getNumTopSegments() > 0) {
@@ -175,6 +176,7 @@ void MafWriteGenomes::initBlockInfo(size_t col) {
             assert(_dimMap->find(_block[i]._sequenceName) != _dimMap->end());
             _blockInfo[i]._record = _dimMap->find(_block[i]._sequenceName)->second;
             _blockInfo[i]._genome = _alignment->openGenome(genomeName(_block[i]._sequenceName));
+            assert(_blockInfo[i]._genome != NULL);
             _blockInfo[i]._skip = false;
             // correction for - strand: need to iterate index right to left
             // so keep a correctly flipped maf line here (rather than doing it
@@ -262,6 +264,7 @@ void MafWriteGenomes::initParaMap() {
     for (size_t i = 0; i < _rows; ++i) {
         Row &row = _block[i];
         Genome *genome = _alignment->openGenome(genomeName(row._sequenceName));
+        assert(genome != NULL);
         Sequence *sequence = genome->getSequence(sequenceName(row._sequenceName));
         assert(sequence != NULL);
         Paralogy para = {sequence->getStartPosition() + static_cast<hal_index_t>(row._startPosition), i};

--- a/maf/impl/maf2hal.cpp
+++ b/maf/impl/maf2hal.cpp
@@ -69,9 +69,12 @@ int main(int argc, char **argv) {
         AlignmentPtr alignment;
         if (append == true) {
             alignment = AlignmentPtr(openHalAlignment(halPath, &optionsParser, WRITE_ACCESS));
-            const Genome *refGenome = alignment->openGenome(refGenomeName);
-            if (alignment->openGenome(refGenomeName)->getNumChildren() > 0) {
-                throw hal_exception("Reference genome " + refGenomeName + " not a leaf in hal file");
+            if (alignment->openGenome(refGenomeName) == NULL) {
+                throw hal_exception("Reference genome " + refGenomeName + " not found "
+                                                                          "in hal file");
+            } else if (alignment->openGenome(refGenomeName)->getNumChildren() > 0) {
+                throw hal_exception("Reference genome " + refGenomeName + " not a leaf "
+                                                                          "in hal file");
             }
         } else {
             alignment = AlignmentPtr(openHalAlignment(halPath, &optionsParser, CREATE_ACCESS));

--- a/modify/ancestorsML.cpp
+++ b/modify/ancestorsML.cpp
@@ -335,6 +335,7 @@ void writeNucleotides(stTree *tree, AlignmentConstPtr alignment, const Genome *t
         return;
     }
     const Genome *genome = alignment->openGenome(stTree_getLabel(tree));
+    assert(genome != NULL);
     DnaIteratorPtr dnaIt = genome->getDnaIterator(data->pos);
     if (data->reversed) {
         dnaIt->toReverse();

--- a/modify/ancestorsMLMain.cpp
+++ b/modify/ancestorsMLMain.cpp
@@ -66,6 +66,9 @@ int main(int argc, char *argv[]) {
 
     AlignmentPtr alignment = openHalAlignment(halPath, &optParser);
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception("Genome " + genomeName + " not found in alignment.");
+    }
     if (genome->getNumChildren() == 0) {
         throw hal_exception("Genome " + genomeName + " is a leaf genome.");
     }

--- a/modify/halRenameGenomes.cpp
+++ b/modify/halRenameGenomes.cpp
@@ -33,6 +33,10 @@ int main(int argc, char *argv[]) {
     // of the new genome names.
     for (map<string, string>::iterator it = renameMap.begin(); it != renameMap.end(); it++) {
         Genome *genome = alignment->openGenome(it->first);
+        if (genome == NULL) {
+            throw hal_exception("Genome " + it->first + " not found in alignment");
+        }
+
         genome = alignment->openGenome(it->second);
         if (genome != NULL) {
             throw hal_exception("Attempting to rename " + it->first + " to " + it->second + " failed: " + it->second +

--- a/modify/halRenameSequences.cpp
+++ b/modify/halRenameSequences.cpp
@@ -30,6 +30,9 @@ int main(int argc, char *argv[]) {
 
     AlignmentPtr alignment(openHalAlignment(halPath, &optionsParser, WRITE_ACCESS | READ_ACCESS));
     Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception("Genome " + genomeName + " not found in alignment");
+    }
     map<string, string> renameMap = ingestRenameFile(renamePath);
 
     for (map<string, string>::iterator it = renameMap.begin(); it != renameMap.end(); it++) {

--- a/modify/halSetMetadata.cpp
+++ b/modify/halSetMetadata.cpp
@@ -38,6 +38,9 @@ int main(int argc, char *argv[]) {
         metadata->set(key, value);
     } else {
         Genome *genome = alignment->openGenome(genomeName);
+        if (genome == NULL) {
+            throw hal_exception("No genome named " + genomeName + " in alignment");
+        }
         MetaData *metadata = genome->getMetaData();
         metadata->set(key, value);
     }

--- a/modify/markAncestors.cpp
+++ b/modify/markAncestors.cpp
@@ -6,11 +6,9 @@ using namespace hal;
 // Mark that all nodes above this one (but not this one) need to be
 // updated.
 void markAncestorsForUpdate(AlignmentPtr alignment, string node) {
-    Genome *parent = NULL;
-    try {
-        parent = alignment->openGenome(alignment->getParentName(node));
-    } catch (const GenomeNotFoundException& ex) {
-        return;  // ignore, not sure why, original code did this.
+    Genome *parent = alignment->openGenome(alignment->getParentName(node));
+    if (!parent) {
+        return;
     }
     MetaData *metadata = parent->getMetaData();
     metadata->set("needsUpdate", "true");

--- a/mutations/impl/halBranchMutationsMain.cpp
+++ b/mutations/impl/halBranchMutationsMain.cpp
@@ -100,6 +100,9 @@ int main(int argc, char **argv) {
 
         const Genome *refGenome = NULL;
         refGenome = alignment->openGenome(refGenomeName);
+        if (refGenome == NULL) {
+            throw hal_exception(string("Reference genome, ") + refGenomeName + ", not found in alignment");
+        }
         if (refGenome->getName() == alignment->getRootName()) {
             throw hal_exception("Reference genome must denote bottom node in "
                                 "a branch, and therefore cannot be the root.");

--- a/mutations/impl/halIndels.cpp
+++ b/mutations/impl/halIndels.cpp
@@ -419,6 +419,9 @@ int main(int argc, char *argv[]) {
 
     AlignmentConstPtr alignment(openHalAlignment(halPath, &optionsParser));
     const Genome *refGenome = alignment->openGenome(refGenomeName);
+    if (refGenome == NULL) {
+        throw hal_exception("Genome " + refGenomeName + " does not exist");
+    }
     if (refGenome->getParent() == NULL) {
         throw hal_exception("Cannot use the root genome as a reference.");
     }

--- a/mutations/impl/halSnps.cpp
+++ b/mutations/impl/halSnps.cpp
@@ -89,11 +89,17 @@ int main(int argc, char **argv) {
 
         const Genome *refGenome = NULL;
         refGenome = alignment->openGenome(refGenomeName);
+        if (refGenome == NULL) {
+            throw hal_exception(string("Reference genome, ") + refGenomeName + ", not found in alignment");
+        }
 
         vector<string> targetGenomeNames = chopString(targetGenomesString, ",");
         set<const Genome *> targetGenomes;
         for (hal_size_t i = 0; i < targetGenomeNames.size(); i++) {
             const Genome *genome = alignment->openGenome(targetGenomeNames[i]);
+            if (genome == NULL) {
+                throw hal_exception("Target genome " + targetGenomeNames[i] + " not found in alignment.");
+            }
             targetGenomes.insert(genome);
         }
 

--- a/mutations/impl/halSummarizeMutations.cpp
+++ b/mutations/impl/halSummarizeMutations.cpp
@@ -67,6 +67,7 @@ void SummarizeMutations::analyzeAlignmentPtr(AlignmentConstPtr alignment, hal_si
 
 void SummarizeMutations::analyzeGenomeRecursive(const string &genomeName) {
     const Genome *genome = _alignment->openGenome(genomeName);
+    assert(genome != NULL);
     const Genome *parent = genome->getParent();
     MutationsStats stats = {0};
     stats._genomeLength = genome->getSequenceLength();

--- a/mutations/impl/halSummarizeMutationsMain.cpp
+++ b/mutations/impl/halSummarizeMutationsMain.cpp
@@ -77,6 +77,9 @@ int main(int argc, char **argv) {
         const Genome *rootGenome = NULL;
         if (rootGenomeName != "\"\"") {
             rootGenome = alignment->openGenome(rootGenomeName);
+            if (rootGenome == NULL) {
+                throw hal_exception(string("Root genome, ") + rootGenomeName + ", not found in alignment");
+            }
             if (rootGenomeName != alignment->getRootName()) {
                 getGenomesInSubTree(rootGenome, targetSet);
             } else {
@@ -88,6 +91,9 @@ int main(int argc, char **argv) {
             vector<string> targetNames = chopString(targetGenomes, ",");
             for (size_t i = 0; i < targetNames.size(); ++i) {
                 const Genome *tgtGenome = alignment->openGenome(targetNames[i]);
+                if (tgtGenome == NULL) {
+                    throw hal_exception(string("Target genome, ") + targetNames[i] + ", not found in alignment");
+                }
                 targetSet.insert(tgtGenome);
             }
         }

--- a/paf/hal2paf.cpp
+++ b/paf/hal2paf.cpp
@@ -64,6 +64,10 @@ int main(int argc, char **argv) {
         } else {
             rootGenome = alignment->openGenome(alignment->getRootName());
         }
+        if (rootGenome == NULL) {
+            throw hal_exception(string("Root genome, ") + rootGenomeName + 
+                                ", not found in alignment");
+        }
         const Genome* parentGenome = rootGenome;
 
         vector<string> childs = alignment->getChildNames(rootGenome->getName());

--- a/phyloP/impl/halPhyloP.cpp
+++ b/phyloP/impl/halPhyloP.cpp
@@ -78,13 +78,7 @@ void PhyloP::init(AlignmentConstPtr alignment, const string &modFilePath, ostrea
     char **names = (char **)smalloc(numleaf * sizeof(char *));
     for (int i = 0; i < lst_size(leafNames); i++) {
         string targetName = string(((String *)lst_get_ptr(leafNames, i))->chars);
-       
-        const Genome *tgtGenome = NULL;
-        try {
-            tgtGenome = _alignment->openGenome(targetName);
-        } catch (const GenomeNotFoundException& ex) {
-        }
-
+        const Genome *tgtGenome = _alignment->openGenome(targetName);
         if (tgtGenome == NULL) {
             cerr << "Genome" << targetName << " not found in alignment; pruning from tree" << endl;
             lst_push(pruneNames, lst_get_ptr(leafNames, i));

--- a/phyloP/impl/halPhyloPMain.cpp
+++ b/phyloP/impl/halPhyloPMain.cpp
@@ -122,6 +122,9 @@ int main(int argc, char **argv) {
         const Genome *refGenome = NULL;
         if (refGenomeName != "\"\"") {
             refGenome = alignment->openGenome(refGenomeName);
+            if (refGenome == NULL) {
+                throw hal_exception(string("Reference genome, ") + refGenomeName + ", not found in alignment");
+            }
         } else {
             refGenome = alignment->openGenome(alignment->getRootName());
         }

--- a/stats/impl/halStatsMain.cpp
+++ b/stats/impl/halStatsMain.cpp
@@ -296,6 +296,9 @@ void printGenomes(ostream &os, AlignmentConstPtr alignment) {
 
 void printSequences(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception(string("Genome ") + genomeName + " not found.");
+    }
     if (genome->getNumSequences() > 0) {
         for (SequenceIteratorPtr seqIt = genome->getSequenceIterator(); not seqIt->atEnd(); seqIt->toNext()) {
             if (!seqIt->equals(genome->getSequenceIterator())) {
@@ -309,6 +312,9 @@ void printSequences(ostream &os, AlignmentConstPtr alignment, const string &geno
 
 void printSequenceStats(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception(string("Genome ") + genomeName + " not found.");
+    }
     if (genome->getNumSequences() > 0) {
         os << "SequenceName, Length, NumTopSegments, NumBottomSegments" << endl;
 
@@ -322,6 +328,9 @@ void printSequenceStats(ostream &os, AlignmentConstPtr alignment, const string &
 
 void printBedSequenceStats(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception(string("Genome ") + genomeName + " not found.");
+    }
     if (genome->getNumSequences() > 0) {
         for (SequenceIteratorPtr seqIt = genome->getSequenceIterator(); not seqIt->atEnd(); seqIt->toNext()) {
             os << seqIt->getSequence()->getName() << "\t" << 0 << "\t" << seqIt->getSequence()->getSequenceLength() << "\n";
@@ -333,6 +342,9 @@ static void printBranchPath(ostream &os, AlignmentConstPtr alignment, const vect
     set<const Genome *> inputSet;
     for (size_t i = 0; i < genomeNames.size(); ++i) {
         const Genome *genome = alignment->openGenome(genomeNames[i]);
+        if (genome == NULL) {
+            throw hal_exception(string("Genome ") + genomeNames[i] + " not found");
+        }
         inputSet.insert(genome);
     }
     set<const Genome *> outputSet;
@@ -426,6 +438,9 @@ void printBranchLength(ostream &os, AlignmentConstPtr alignment, const string &g
 
 void printNumSegments(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception(string("Genome ") + genomeName + " not found.");
+    }
     os << genome->getNumTopSegments() << " " << genome->getNumBottomSegments() << endl;
 }
 
@@ -443,6 +458,9 @@ void printBaseComp(ostream &os, AlignmentConstPtr alignment, const string &baseC
     }
 
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception(string("Genome ") + genomeName + " not found.");
+    }
     hal_size_t numA = 0;
     hal_size_t numC = 0;
     hal_size_t numG = 0;
@@ -485,6 +503,9 @@ void printBaseComp(ostream &os, AlignmentConstPtr alignment, const string &baseC
 
 void printGenomeMetaData(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception("Genome not found: " + genomeName);
+    }
     const MetaData *metaData = genome->getMetaData();
     const map<string, string> metaDataMap = metaData->getMap();
     map<string, string>::const_iterator mapIt = metaDataMap.begin();
@@ -505,6 +526,9 @@ void printAlignmentPtrMetaData(ostream &os, AlignmentConstPtr alignment) {
 
 void printChromSizes(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception(string("Genome ") + genomeName + " not found.");
+    }
     if (genome->getNumSequences() > 0) {
 
         for (SequenceIteratorPtr seqIt = genome->getSequenceIterator(); not seqIt->atEnd(); seqIt->toNext()) {
@@ -515,6 +539,9 @@ void printChromSizes(ostream &os, AlignmentConstPtr alignment, const string &gen
 
 void printPercentID(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *refGenome = alignment->openGenome(genomeName);
+    if (!refGenome) {
+        throw hal_exception("Genome " + genomeName + " does not exist.");
+    }
 
     ColumnIteratorPtr colIt = refGenome->getColumnIterator();
     // A bit sloppy, but a mapping from genome to (# identical bases, # aligned sites)
@@ -613,6 +640,9 @@ void printPercentID(ostream &os, AlignmentConstPtr alignment, const string &geno
 
 void printCoverage(ostream &os, AlignmentConstPtr alignment, const string &genomeName) {
     const Genome *refGenome = alignment->openGenome(genomeName);
+    if (!refGenome) {
+        throw hal_exception("Genome " + genomeName + " does not exist.");
+    }
 
     ColumnIteratorPtr colIt = refGenome->getColumnIterator(NULL, 0, 0, NULL_INDEX, false, false, false, true);
     map<const Genome *, vector<hal_size_t> *> histograms;
@@ -693,6 +723,9 @@ void printCoverage(ostream &os, AlignmentConstPtr alignment, const string &genom
 
 static void printSegments(ostream &os, AlignmentConstPtr alignment, const string &genomeName, bool top) {
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception("Genome " + genomeName + " does not exist.");
+    }
     hal_size_t numSegments = 0;
     SegmentIteratorPtr segment;
     if (top == true) {

--- a/synteny/impl/halSynteny.cpp
+++ b/synteny/impl/halSynteny.cpp
@@ -27,6 +27,9 @@ static void initParser(CLParser &optionsParser) {
 
 const Genome *openGenomeOrThrow(AlignmentConstPtr alignment, const std::string &genomeName) {
     const Genome *genome = alignment->openGenome(genomeName);
+    if (genome == NULL) {
+        throw hal_exception(std::string("Reference genome, ") + genomeName + ", not found in alignment");
+    }
     return genome;
 }
 
@@ -92,8 +95,8 @@ static void syntenyBlockForChrom(AlignmentConstPtr alignment,
 static void syntenyFromHal(AlignmentConstPtr alignment, std::string queryGenomeName,
                            std::string targetGenomeName, std::string queryChromosome,
                            hal_size_t minBlockSize, hal_size_t maxAnchorDistance, std::string outPslPath) {
-    auto targetGenome = alignment->openGenome(targetGenomeName);
-    auto queryGenome = alignment->openGenome(queryGenomeName);
+    auto targetGenome = openGenomeOrThrow(alignment, targetGenomeName);
+    auto queryGenome = openGenomeOrThrow(alignment, queryGenomeName);
     std::vector<std::string> chromNames;
     if (queryChromosome != "\"\"") {
         chromNames.push_back(queryChromosome);


### PR DESCRIPTION
This change broke both [cactus](https://github.com/ComparativeGenomicsToolkit/cactus) and [hal2vg](https://github.com/ComparativeGenomicsToolkit/hal2vg).  It probably breaks some tools within hal as other sweeping refactors have done (ex #149), and could affect anyone else using the API which, given [23 forks](https://github.com/ComparativeGenomicsToolkit/hal/network/members), isn't so improbable. 

For better of for worse, the only way to check if a genome is present in an alignment is calling `openGenome()` and testing for a null.  If there's a tool that's expecting something non-null and not checking, then it needs to be fixed.  It's just too late in the game to make such a giant semantic api change to fix one case like this.      
