### PR TITLE
Revert recent changes in hal2fasta naming scheme

### DIFF
--- a/fasta/hal2fasta.cpp
+++ b/fasta/hal2fasta.cpp
@@ -28,9 +28,8 @@ static void initParser(CLParser &optionsParser) {
     optionsParser.addArgument("inHalPath", "input hal file");
     optionsParser.addArgument("genome", "genome to export");
     optionsParser.addOption("outFaPath", "output fasta file (stdout if none)", "stdout");
-    optionsParser.addOptionFlag("onlySequenceNames", "use only sequence names "
-                                "for output names.  By default, the UCSC convention of Genome.Sequence "
-                                "is used",
+    optionsParser.addOptionFlag("ucscSequenceNames", "Use the UCSC convention of Genome.Sequence for names."
+                                " By default, only sequence names are used",
                                 false);
     optionsParser.addOption("lineWidth", "Line width for output", 80);
     optionsParser.addOption("sequence", "sequence name to export ("
@@ -68,7 +67,7 @@ int main(int argc, char **argv) {
         halPath = optionsParser.getArgument<string>("inHalPath");
         genomeName = optionsParser.getArgument<string>("genome");
         faPath = optionsParser.getOption<string>("outFaPath");
-        fullNames = !optionsParser.getFlag("onlySequenceNames");
+        fullNames = optionsParser.getFlag("ucscSequenceNames");
         lineWidth = optionsParser.getOption<hal_size_t>("lineWidth");
         sequenceName = optionsParser.getOption<string>("sequence");
         start = optionsParser.getOption<hal_size_t>("start");


### PR DESCRIPTION
Well, well, well..  look what we have here:

While I'm berating others on github for making breaking changes to hal, it looks like my latest assembly hub problem comes from this change I made to hal2fasta:

https://github.com/ComparativeGenomicsToolkit/hal/commit/04b8c5578d005ba60c274dae5d2b70bb44c31f7c#diff-bf753ceed13f4e90e3b8309b2252dfd8

Which I'm reverting here: so hal2fata will output only sequence names again by default (though the new option to change that is kept, it's just flipped).  

Crow = eaten.  