### PR TITLE
Specify phast commit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ From the same parent directory where you downloaded HAL:
 *  Install Phast (Mac or Linux)
 
      `git clone https://github.com/CshlSiepelLab/phast.git`  
-     `cd phast`  
+     `cd phast`
+     `git checkout 52e8de92a91e09434e60a03b7835e7363cf97007`
      `cd src && make`  
      `cd ../..`  
 


### PR DESCRIPTION
This is the version on my machine that HAL seems to build on.  Still would be a good idea to migrate (and test) the latest release. 