### PR TITLE
changed logic of psl construction in case strands are different

### DIFF
--- a/synteny/impl/psl_io.cpp
+++ b/synteny/impl/psl_io.cpp
@@ -71,8 +71,14 @@ namespace psl_io {
         psl.strand = blocks[0].strand;
         psl.blockCount = blocks.size();
         psl.blocks = blocks;
-        psl.tStart = blocks.front().tStart;
-        psl.tEnd = blocks.back().tEnd;
+        if (psl.strand == "++") {
+		psl.tStart = blocks.front().tStart;
+    		psl.tEnd = blocks.back().tEnd;
+    	}
+    	else if (psl.strand == "+-") {
+        	psl.tEnd = psl.tSize - blocks[0].tStart;
+        	psl.tStart = psl.tSize - blocks.back().tEnd;
+    	}
         return psl;
     }
 


### PR DESCRIPTION
Suggestions to fix [https://github.com/ComparativeGenomicsToolkit/hal/issues/225](https://github.com/ComparativeGenomicsToolkit/hal/issues/225)
Works fine on the test example