### PR TITLE
fixing topSegments of insertName's node (again)

### DIFF
--- a/modify/halAddToBranch.cpp
+++ b/modify/halAddToBranch.cpp
@@ -77,16 +77,16 @@ int main(int argc, char *argv[]) {
     botParentGenome->copyBottomSegments(parentGenome);
     parentGenome->fixParseInfo();
 
-    // Fix the parent's other children as well.
+    // Fix the parent's children
     vector<string> allChildren = mainAlignment->getChildNames(parentName);
     for (size_t i = 0; i < allChildren.size(); i++) {
-        if (allChildren[i] != insertName) {
+        //if (allChildren[i] != insertName) {
             Genome *outGenome = mainAlignment->openGenomeCheck(allChildren[i]);
             const Genome *topSegmentsGenome = topAlignment->openGenomeCheck(allChildren[i]);
             topSegmentsGenome->copyTopDimensions(outGenome);
             topSegmentsGenome->copyTopSegments(outGenome);
             outGenome->fixParseInfo();
-        }
+        //}
     }
 
     // Copy the top segments for the child genome from the bottom alignment.


### PR DESCRIPTION
An (ugly) patch to solve an unknown problem with the `topSegment` copy to the new intermediate node. Still don't have a clue why the `topSegment` of the new node should be updated again.

Shall open an issue to propose a better solution?

Source data: https://storage.googleapis.com/cactus-slurm-processing-data/halAddToBrach.tar.gz

Adding a node to a branch:
```
halAddToBranch hal/evolverMammals.hal steps/mr_child.hal steps/mr.hal mr mr_child simRat_chr6 simChimp 0.1 0.1 --hdf5InMemory
```

Validating message error:
```
halValidate --genome mr hal/evolverMammals.hal --hdf5InMemory
hal exception caught: Parent / child index mismatch:
mr[4768] links to mr_child[8973] but
mr_child[8973] links to mr[13437]
```
```
halValidate --genome mr_child hal/evolverMammals.hal --hdf5InMemory
hal exception caught: Parent index 37448 of segment 2746 out of range in genome mr
```