### PR TITLE
fix UDC build

### DIFF
--- a/blockViz/Makefile
+++ b/blockViz/Makefile
@@ -26,6 +26,23 @@ all: libs progs
 libs: ${libHalBlockViz}
 progs: ${progs}
 
+# only blockVizTest/Maf.cpp should include kent .h files, to preven conflicts with older versions of
+# phast
+${modObjDir}/tests/blockVizTest.o : tests/blockVizTest.cpp
+	@mkdir -p $(dir $@)
+	${CXX} -MM -MT $@ ${CXXFLAGS} ${UDCCXXFLAGS} ${inclSpec} -c $< >$*.depend
+	${CXX} ${CXXFLAGS} ${UDCCXXFLAGS} ${inclSpec} -c $< -o $@
+
+${modObjDir}/tests/blockVizMaf.o : tests/blockVizMaf.cpp
+	@mkdir -p $(dir $@)
+	${CXX} -MM -MT $@ ${CXXFLAGS} ${UDCCXXFLAGS} ${inclSpec} -c $< >$*.depend
+	${CXX} ${CXXFLAGS} ${UDCCXXFLAGS} ${inclSpec} -c $< -o $@
+
+${modObjDir}/tests/blockVizBed.o : tests/blockVizBed.cpp
+	@mkdir -p $(dir $@)
+	${CXX} -MM -MT $@ ${CXXFLAGS} ${UDCCXXFLAGS} ${inclSpec} -c $< >$*.depend
+	${CXX} ${CXXFLAGS} ${UDCCXXFLAGS} ${inclSpec} -c $< -o $@
+
 clean: 
 	rm -f ${libHalBlockViz} ${objs} ${progs} ${depends}
 	rm -rf ${testTmpDir}

--- a/include.mk
+++ b/include.mk
@@ -105,7 +105,9 @@ endif
 ifdef ENABLE_UDC
     #  Find htslib as in kent/src/inc/common.mk:
     MACHTYPE = x86_64
-    UDCCXXFLAGS += -DENABLE_UDC -I${KENTSRC}/inc -I${KENTSRC}/htslib -pthread
+    CXXFLAGS += -DENABLE_UDC
+    CFLAGS += -DENABLE_UDC
+    UDCCXXFLAGS += -I${KENTSRC}/inc -I${KENTSRC}/htslib -pthread
     UDCCFLAGS += -Wall -Werror -std=c99 -I${KENTSRC}/inc -I${KENTSRC}/htslib
     LDLIBS += ${KENTSRC}/lib/${MACHTYPE}/jkweb.a  ${KENTSRC}/htslib/libhts.a -lcurl -lssl -lcrypto -pthread
 endif


### PR DESCRIPTION
`-DENABLE_UDC` got dropped from the build somewhere along the line, this puts it back.  