### PR TITLE
Allow halAppendSubtree to be run with --inMemory

### DIFF
--- a/modify/halAppendSubtree.cpp
+++ b/modify/halAppendSubtree.cpp
@@ -40,11 +40,15 @@ void addSubtree(AlignmentPtr mainAlignment, AlignmentConstPtr appendAlignment, s
             mainAlignment->addLeafGenome(children[i], currNode, appendAlignment->getBranchLength(currNode, children[i]));
         const Genome *appendChildGenome = appendAlignment->openGenome(children[i]);
         appendChildGenome->copy(mainChildGenome);
+        mainAlignment->closeGenome(mainChildGenome);
+        appendAlignment->closeGenome(appendChildGenome);
         addSubtree(mainAlignment, appendAlignment, children[i]);
     }
     inGenome->copyBottomDimensions(outGenome);
     inGenome->copyBottomSegments(outGenome);
     outGenome->fixParseInfo();
+    mainAlignment->closeGenome(outGenome);
+    appendAlignment->closeGenome(inGenome);
 }
 
 int main(int argc, char *argv[]) {
@@ -80,6 +84,7 @@ int main(int argc, char *argv[]) {
         Genome *mainAppendedRoot = mainAlignment->addLeafGenome(rootName, parentName, branchLength);
         const Genome *appendAppendedRoot = appendAlignment->openGenome(rootName);
         appendAppendedRoot->copy(mainAppendedRoot);
+        appendAlignment->closeGenome(appendAppendedRoot);
     } else {
         // the bridge alignment is equivalent to the append alignment in this case
         // (the append alignment will contain at least all the information that
@@ -99,6 +104,8 @@ int main(int argc, char *argv[]) {
     bridgeParentGenome->copyBottomDimensions(mainParentGenome);
     bridgeParentGenome->copyBottomSegments(mainParentGenome);
     mainParentGenome->fixParseInfo();
+    mainAlignment->closeGenome(mainParentGenome);
+    bridgeAlignment->closeGenome(bridgeParentGenome);
 
     // And top segments for its children
     vector<string> children = bridgeAlignment->getChildNames(parentName);
@@ -108,6 +115,8 @@ int main(int argc, char *argv[]) {
         bridgeChildGenome->copyTopDimensions(mainChildGenome);
         bridgeChildGenome->copyTopSegments(mainChildGenome);
         mainChildGenome->fixParseInfo();
+        mainAlignment->closeGenome(mainChildGenome);
+        bridgeAlignment->closeGenome(bridgeChildGenome);
     }
 
     if (!noMarkAncestors) {

--- a/modify/halAppendSubtree.cpp
+++ b/modify/halAppendSubtree.cpp
@@ -39,6 +39,7 @@ void addSubtree(AlignmentPtr mainAlignment, AlignmentConstPtr appendAlignment, s
         Genome *mainChildGenome =
             mainAlignment->addLeafGenome(children[i], currNode, appendAlignment->getBranchLength(currNode, children[i]));
         const Genome *appendChildGenome = appendAlignment->openGenome(children[i]);
+        cerr << "[halAppendSubtree] Copying " << children[i] << endl;
         appendChildGenome->copy(mainChildGenome);
         mainAlignment->closeGenome(mainChildGenome);
         appendAlignment->closeGenome(appendChildGenome);
@@ -83,6 +84,7 @@ int main(int argc, char *argv[]) {
         bridgeAlignment = AlignmentConstPtr(openHalAlignment(bridgePath, &optionsParser));
         Genome *mainAppendedRoot = mainAlignment->addLeafGenome(rootName, parentName, branchLength);
         const Genome *appendAppendedRoot = appendAlignment->openGenome(rootName);
+        cerr << "[halAppendSubtree] Copying " << rootName << endl;
         appendAppendedRoot->copy(mainAppendedRoot);
         appendAlignment->closeGenome(appendAppendedRoot);
     } else {


### PR DESCRIPTION
By explicitly closing every genome ASAP, we limit the number of genomes in memory to one or two.  This means that `--inMemory` can now be used when using `halAppendSubtree` on giant files.

Now why `--inMemory` would help this tool (which has very regular access) so much I'm not sure, but it seems to be about 50X faster on courtyard (still super slow tho).  

 