### PR TITLE
add halRemoveSubtree

### DIFF
--- a/modify/Makefile
+++ b/modify/Makefile
@@ -8,6 +8,8 @@ renameFile_srcs = renameFile.cpp
 renameFile_objs = ${renameFile_srcs:%.cpp=${modObjDir}/%.o}
 halRemoveGenome_srcs = halRemoveGenome.cpp
 halRemoveGenome_objs = ${halRemoveGenome_srcs:%.cpp=${modObjDir}/%.o} ${markAncestors_objs}
+halRemoveSubtree_srcs = halRemoveSubtree.cpp
+halRemoveSubtree_objs = ${halRemoveSubtree_srcs:%.cpp=${modObjDir}/%.o} ${markAncestors_objs}
 halAddToBranch_srcs = halAddToBranch.cpp
 halAddToBranch_objs = ${halAddToBranch_srcs:%.cpp=${modObjDir}/%.o} ${markAncestors_objs}
 halReplaceGenome_srcs = halReplaceGenome.cpp
@@ -30,14 +32,14 @@ ancestorsML_srcs = ancestorsML.cpp ancestorsMLMain.cpp ancestorsMLBed.cpp
 ancestorsML_objs = ${ancestorsML_srcs:%.cpp=${modObjDir}/%.o}
 ancestorsMLTest_srcs = ancestorsMLTest.cpp ancestorsML.cpp
 ancestorsMLTest_objs = ${ancestorsMLTest_srcs:%.cpp=${modObjDir}/%.o}
-srcs = ${markAncestors_srcs} ${renameFile_srcs} ${halRemoveGenome_srcs} ${halAddToBranch_srcs} \
+srcs = ${markAncestors_srcs} ${renameFile_srcs} ${halRemoveGenome_srcs} ${halRemoveSubtree_srcs} ${halAddToBranch_srcs} \
     ${halReplaceGenome_srcs} ${halAppendSubtree_srcs} \
     ${findRegionsExclusivelyInGroup_srcs} ${halUpdateBranchLengths_srcs} \
     ${halWriteNucleotides_srcs} ${halSetMetadata_srcs} ${halRenameGenomes_srcs} \
     ${halRenameSequences_srcs} ${ancestorsML_srcs} ${ancestorsMLTest_srcs}
 objs = ${srcs:%.cpp=${modObjDir}/%.o}
 depends = ${srcs:%.cpp=%.depend}
-progs = ${binDir}/halRemoveGenome ${binDir}/halAddToBranch ${binDir}/halReplaceGenome ${binDir}/halAppendSubtree ${binDir}/findRegionsExclusivelyInGroup ${binDir}/halUpdateBranchLengths ${binDir}/halWriteNucleotides ${binDir}/halSetMetadata ${binDir}/halRenameGenomes ${binDir}/halRenameSequences
+progs = ${binDir}/halRemoveGenome ${binDir}/halRemoveSubtree ${binDir}/halAddToBranch ${binDir}/halReplaceGenome ${binDir}/halAppendSubtree ${binDir}/findRegionsExclusivelyInGroup ${binDir}/halUpdateBranchLengths ${binDir}/halWriteNucleotides ${binDir}/halSetMetadata ${binDir}/halRenameGenomes ${binDir}/halRenameSequences
 
 inclSpec += -I${rootDir}/liftover/inc ${PHASTCXXFLAGS}
 otherLibs += ${libHalLiftover}

--- a/modify/halRemoveSubtree.cpp
+++ b/modify/halRemoveSubtree.cpp
@@ -1,0 +1,60 @@
+#include "hal.h"
+#include "halCLParser.h"
+#include "markAncestors.h"
+
+using namespace std;
+using namespace hal;
+
+static void initParser(CLParser &optionsParser) {
+    optionsParser.addArgument("inFile", "existing tree");
+    optionsParser.addArgument("root", "subtree below this node will be deleted (but not the node itself)");
+    optionsParser.addOptionFlag("noMarkAncestors", "don't mark ancestors for"
+                                                   " update",
+                                false);
+}
+
+void remove_recursive(AlignmentPtr aln, const string& node) {
+    vector<string> children = aln->getChildNames(node);
+    for (size_t i = 0; i < children.size(); ++i) {
+        remove_recursive(aln, children[i]);
+    }
+    cerr << "[halRemoveSubtree] removing " << node << endl;
+    aln->removeGenome(node);    
+}
+
+int main(int argc, char *argv[]) {
+    CLParser optionsParser(WRITE_ACCESS);
+    initParser(optionsParser);
+    string inPath, root;
+    bool noMarkAncestors;
+    try {
+        optionsParser.parseOptions(argc, argv);
+        inPath = optionsParser.getArgument<string>("inFile");
+        root = optionsParser.getArgument<string>("root");
+        noMarkAncestors = optionsParser.getFlag("noMarkAncestors");
+    } catch (exception &e) {
+        optionsParser.printUsage(cerr);
+        return 1;
+    }
+    AlignmentPtr alignment(openHalAlignment(inPath, &optionsParser, READ_ACCESS | WRITE_ACCESS));
+
+    if (alignment->openGenome(root) == NULL) {
+        cerr << "[halRemoveSubtree] Error: given root " << root << " not found in alignment" << endl;
+        return 1;
+    }
+    
+    if (!noMarkAncestors) {
+        markAncestorsForUpdate(alignment, root);
+    }
+    
+    // the main use case for this is prepping for halAppendSubtree, in which case we
+    // want to leave the root node. 
+    vector<string> children = alignment->getChildNames(root);
+    if (children.empty()) {
+        cerr << "[halRemoveSubtree] Warning: given root " << root << " is a leaf: doing nothing" << endl;
+    }
+    for (size_t i = 0; i < children.size(); ++i) {
+        remove_recursive(alignment, children[i]);
+    }
+    return 0;
+}


### PR DESCRIPTION
I want to be able to replace a clade in a HAL file, but I don't seem to be able to do it simply with current tools.   Idea: destroy it in one shot with this new tool and pop the new one in with `halAppendSubtree`.  (`halExtract` still needed to defragment after)