### PR TITLE
Adjust default HDF5 caching behaviour

### DIFF
--- a/api/hdf5_impl/hdf5Alignment.cpp
+++ b/api/hdf5_impl/hdf5Alignment.cpp
@@ -189,20 +189,6 @@ void Hdf5Alignment::open() {
 #endif
     _metaData = new HDF5MetaData(_file, MetaGroupName);
     loadTree();
-    if (stTree_getNumNodes(_tree) > 199) {
-        // We disable the HDF5 chunk cache with large numbers of species
-        // (over 200 genomes, or 100 leaves with a binary tree), because
-        // every genome opened will cause several new chunk caches to be
-        // initialized. This causes massive memory usage (well over 17
-        // GB for just running halStats on a 250-genome alignment).
-        close();
-        delete _file;
-        _aprops.setCache(0, 0, 0, 0.);
-        _file = new H5File(_alignmentPath.c_str(), _flags, _cprops, _aprops);
-        delete _metaData;
-        _metaData = new HDF5MetaData(_file, MetaGroupName);
-        loadTree();
-    }
 }
 
 void Hdf5Alignment::close() {

--- a/api/hdf5_impl/hdf5Alignment.cpp
+++ b/api/hdf5_impl/hdf5Alignment.cpp
@@ -40,9 +40,12 @@ const H5std_string Hdf5Alignment::VersionGroupName = "Verison";
 
 const hsize_t Hdf5Alignment::DefaultChunkSize = 1000;
 const hsize_t Hdf5Alignment::DefaultCompression = 2;
+// to do: the C-api changed in 1.8 for metadata, and all signs point to the C++ api no longer working
+//        does this have any bearing on memory usage?
 const hsize_t Hdf5Alignment::DefaultCacheMDCElems = 113;
-const hsize_t Hdf5Alignment::DefaultCacheRDCElems = 599999;
-const hsize_t Hdf5Alignment::DefaultCacheRDCBytes = 15728640;
+// using hdf5 defaults as described here: https://docs.h5py.org/en/stable/high/file.html
+const hsize_t Hdf5Alignment::DefaultCacheRDCElems = 521;
+const hsize_t Hdf5Alignment::DefaultCacheRDCBytes = 1048576;
 const double Hdf5Alignment::DefaultCacheW0 = 0.75;
 const bool Hdf5Alignment::DefaultInMemory = false;
 


### PR DESCRIPTION
For anything but huge files, `--inMemory` is usually the only sensible option.  

But... today I learned that for huge files (200+ genomes including ancestors) HAL quietly disables caching altogether, which renders them virtually unusable. 

So this PR stops doing that, but also substantially decreases the default cache sizes in order to blow up less badly on giant files.

What's funny is that the comment about disabling the cache goes `... (well over 17GB for just running halStats on a 250-genome alignment) ...`

and with the cache *disabled*, `hal2maf` regularly uses exactly 17G on just such files.  This goes up to 17.5G with the new caching parameters enabled.  

So there remains a bit of a mystery here:  where is the 17G actually coming from? 