### PR TITLE
Avoid reading all genome's sequences when possible

### DIFF
--- a/api/hdf5_impl/hdf5Alignment.cpp
+++ b/api/hdf5_impl/hdf5Alignment.cpp
@@ -189,20 +189,6 @@ void Hdf5Alignment::open() {
 #endif
     _metaData = new HDF5MetaData(_file, MetaGroupName);
     loadTree();
-    if (stTree_getNumNodes(_tree) > 199) {
-        // We disable the HDF5 chunk cache with large numbers of species
-        // (over 200 genomes, or 100 leaves with a binary tree), because
-        // every genome opened will cause several new chunk caches to be
-        // initialized. This causes massive memory usage (well over 17
-        // GB for just running halStats on a 250-genome alignment).
-        close();
-        delete _file;
-        _aprops.setCache(0, 0, 0, 0.);
-        _file = new H5File(_alignmentPath.c_str(), _flags, _cprops, _aprops);
-        delete _metaData;
-        _metaData = new HDF5MetaData(_file, MetaGroupName);
-        loadTree();
-    }
 }
 
 void Hdf5Alignment::close() {

--- a/api/hdf5_impl/hdf5Alignment.cpp
+++ b/api/hdf5_impl/hdf5Alignment.cpp
@@ -40,9 +40,12 @@ const H5std_string Hdf5Alignment::VersionGroupName = "Verison";
 
 const hsize_t Hdf5Alignment::DefaultChunkSize = 1000;
 const hsize_t Hdf5Alignment::DefaultCompression = 2;
+// to do: the C-api changed in 1.8 for metadata, and all signs point to the C++ api no longer working
+//        does this have any bearing on memory usage?
 const hsize_t Hdf5Alignment::DefaultCacheMDCElems = 113;
-const hsize_t Hdf5Alignment::DefaultCacheRDCElems = 599999;
-const hsize_t Hdf5Alignment::DefaultCacheRDCBytes = 15728640;
+// using hdf5 defaults as described here: https://docs.h5py.org/en/stable/high/file.html
+const hsize_t Hdf5Alignment::DefaultCacheRDCElems = 521;
+const hsize_t Hdf5Alignment::DefaultCacheRDCBytes = 1048576;
 const double Hdf5Alignment::DefaultCacheW0 = 0.75;
 const bool Hdf5Alignment::DefaultInMemory = false;
 

--- a/api/hdf5_impl/hdf5Genome.h
+++ b/api/hdf5_impl/hdf5Genome.h
@@ -168,6 +168,7 @@ namespace hal {
         static const std::string sequenceNameArrayName;
         static const std::string metaGroupName;
         static const std::string rupGroupName;
+        static const hal_size_t maxPosCache;
 
         static const double dnaChunkScale;
     };


### PR DESCRIPTION
`hal2maf`'s memory woes, at least on the big zoonomia alignment, came from an [unexpected place](https://github.com/ComparativeGenomicsToolkit/hal/pull/256#issuecomment-1287396916): Whenever `Hdf5Genome::getSequenceBySite()` is called (which is every time a column iterator touches a genome), it accesses `_sequencePosCache`.  If the cache is empty, then it is loaded into memory. 

The problem is that there are so many sequences in the whole alignment (100's of millions) that even though each one is just a few pointers, the resulting indexes cost tens of gigs, limiting the number of hal2maf processes that can be run in parallel.  Since the column iterator can touch every genome pretty much right away, this causes immediate problems.  

The good news is that `hal2maf` only ever touches this cache via `getSequenceBySite()` (as opposed to other methods that may rely on the name cache).  So we can help things substantially with the following heuristic:

* if they were fewer than 1000 sequences (`Hdf5Genome::maxPosCache`), just fill the cache as before
* otherwise, check the cache, if the sequence is there great, otherwise binary search the external array and add the sequence to the cache once its found and return it.  

On this command 
```
/usr/bin/time -v ./hal2maf  241-mammalian-2020v2.0.hal  test.maf  --refGenome Homo_sapiens --refSequence chr20 --start 50000000 --length 100000 --noDupes --noAncestors 2> log
```
these changes reduce memory consumption from `18.5 G` to ` 0.76 G`.  

Apparently loading all these tiny contigs had an impact on running time, as that was reduced from `23m` to `3m`

