### PR TITLE
patch halAppendSubtree so dimensions always set *before* segments

### DIFF
--- a/modify/halAppendSubtree.cpp
+++ b/modify/halAppendSubtree.cpp
@@ -123,27 +123,38 @@ int main(int argc, char *argv[]) {
         assert(branchLength == 0.0);
     }
     addSubtree(mainAlignment, appendAlignment, rootName);
-
+    
     // Need proper bottom segments for parent genome
+    // 1) Copy dimensions for the genome that's being appended
     Genome *mainParentGenome = mainAlignment->openGenome(parentName);
     const Genome *bridgeParentGenome = bridgeAlignment->openGenome(parentName);
     bridgeParentGenome->copyBottomDimensions(mainParentGenome);
-    bridgeParentGenome->copyBottomSegments(mainParentGenome);
-    mainParentGenome->fixParseInfo();
-    mainAlignment->closeGenome(mainParentGenome);
-    bridgeAlignment->closeGenome(bridgeParentGenome);
-
-    // And top segments for its children
+    
+    // 2) Copy top dimensions for the children
     vector<string> children = bridgeAlignment->getChildNames(parentName);
     for (size_t i = 0; i < children.size(); i++) {
         Genome *mainChildGenome = mainAlignment->openGenome(children[i]);
         const Genome *bridgeChildGenome = bridgeAlignment->openGenome(children[i]);
         bridgeChildGenome->copyTopDimensions(mainChildGenome);
+    }
+
+    // 3) copy bottom segments for the genome that's being appended
+    bridgeParentGenome->copyBottomSegments(mainParentGenome);
+    mainParentGenome->fixParseInfo();
+    
+    // 4) copu top segments for its children
+    for (size_t i = 0; i < children.size(); i++) {
+        Genome *mainChildGenome = mainAlignment->openGenome(children[i]);
+        const Genome *bridgeChildGenome = bridgeAlignment->openGenome(children[i]);
         bridgeChildGenome->copyTopSegments(mainChildGenome);
         mainChildGenome->fixParseInfo();
         mainAlignment->closeGenome(mainChildGenome);
         bridgeAlignment->closeGenome(bridgeChildGenome);
-    }
+    } 
+    
+    mainAlignment->closeGenome(mainParentGenome);
+    bridgeAlignment->closeGenome(bridgeParentGenome);
+
 
     if (!noMarkAncestors) {
         markAncestorsForUpdate(mainAlignment, rootName);


### PR DESCRIPTION
This patch copies dimensions before segments in the halAppendSubtree in a similar way as https://github.com/ComparativeGenomicsToolkit/hal/commit/0b35950b07b01e14f5c084794d887cb79c8a733e (`halReplaceGenomes`) and https://github.com/ComparativeGenomicsToolkit/hal/commit/ab7d889a31c99d74d477132eb136a2f89e859654 (`halAddToBranch`).

This patch aims to fix the error `Program received signal SIGSEGV, Segmentation fault` while running the first job of the last step of Cactus (`HAL merging`). I have been facing this error in two completely different alignments (123-way **fish** and 37-way **wheat**). The lines below show `gdb` log for both examples:

1. Fish:
```bash
[thiagogenez_ebi_ac_uk@slurm-prj-int-dev-isp-wheat-controller fish]$ gdb $HOME/cactus/bin/halAppendSubtree
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-120.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /home/thiagogenez_ebi_ac_uk/cactus/bin/halAppendSubtree...done.
(gdb) set args steps/123-way-fish-final.hal steps/Anc002.hal Anc002 Anc002 --merge --hdf5InMemory
(gdb) r
Starting program: /home/thiagogenez_ebi_ac_uk/cactus/bin/halAppendSubtree steps/123-way-fish-final.hal steps/Anc002.hal Anc002 Anc002 --merge --hdf5InMemory
[halAppendSubtree] Copying Anc004
[halAppendSubtree] Copying Anc005

Program received signal SIGSEGV, Segmentation fault.
0x0000000000431109 in hal::Genome::copyTopDimensions(hal::Genome*) const ()
    at /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr_base.h:1020
1020	      _M_get() const noexcept
(gdb) where
#0  0x0000000000431109 in hal::Genome::copyTopDimensions(hal::Genome*) const ()
    at /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr_base.h:1020
#1  0x000000000041758e in main () at halAppendSubtree.cpp:141
#2  0x000000000080fd54 in generic_start_main ()
#3  0x000000000080ffd1 in __libc_start_main ()
#4  0x00000000004192d6 in _start ()
    at /opt/rh/devtoolset-9/root/usr/include/c++/9/ext/new_allocator.h:89
(gdb) steps/Anc002.hal
```

2. Wheat
```bash
[thiagogenez_ebi_ac_uk@slurm-prj-int-dev-isp-wheat-controller wheat]$ gdb $HOME/cactus/bin/halAppendSubtree
GNU gdb (GDB) Red Hat Enterprise Linux 7.6.1-120.el7
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>...
Reading symbols from /home/thiagogenez_ebi_ac_uk/cactus/bin/halAppendSubtree...done.
(gdb) set args steps/37-way-wheat.hal steps/Anc01.hal Anc01 Anc01 --merge --hdf5InMemory
(gdb) r
Starting program: /home/thiagogenez_ebi_ac_uk/cactus/bin/halAppendSubtree steps/37-way-wheat.hal steps/Anc01.hal Anc01 Anc01 --merge --hdf5InMemory
[halAppendSubtree] Copying hordeum_vulgare
[halAppendSubtree] Copying Anc02

Program received signal SIGSEGV, Segmentation fault.
0x0000000000431109 in hal::Genome::copyTopDimensions(hal::Genome*) const () at /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr_base.h:1020
1020	      _M_get() const noexcept
(gdb) WHERE
#0  0x0000000000431109 in hal::Genome::copyTopDimensions(hal::Genome*) const () at /opt/rh/devtoolset-9/root/usr/include/c++/9/bits/shared_ptr_base.h:1020
#1  0x000000000041758e in main () at halAppendSubtree.cpp:141
#2  0x000000000080fd54 in generic_start_main ()
#3  0x000000000080ffd1 in __libc_start_main ()
#4  0x00000000004192d6 in _start () at /opt/rh/devtoolset-9/root/usr/include/c++/9/ext/new_allocator.h:89
```

To reproduce the errors above, I made the files for both cases (fish and wheat) available for download at https://storage.googleapis.com/37-way-wheat/issue/halAppendSubtree-issue.tar.gz.

After this patch is applied, I was able to build the final HAL files for both alignments with `halValidade` outputting `File valid` for each `halAppendSubtree` call.

1. Fish
```bash
halAppendSubtree steps/123-way-fish-final.hal steps/Anc002.hal Anc002 Anc002 --merge --hdf5InMemory
[halAppendSubtree] Copying Anc004
[halAppendSubtree] Copying Anc005

halValidate steps/123-way-fish-final.hal
File valid
```

2. Wheat
```bash
$ halAppendSubtree steps/37-way-wheat.hal steps/Anc01.hal Anc01 Anc01 --merge --hdf5InMemory
[halAppendSubtree] Copying hordeum_vulgare
[halAppendSubtree] Copying Anc02

$ halValidade steps/37-way-wheat.hal
File valid
```