### PR TITLE
Don't skip already-seen reference positions in hal2maf unless (--unique used).

### DIFF
--- a/maf/impl/halMafExport.cpp
+++ b/maf/impl/halMafExport.cpp
@@ -45,7 +45,7 @@ void MafExport::convertSequence(ostream &mafStream, AlignmentConstPtr alignment,
 
     ColumnIteratorPtr colIt = seq->getColumnIterator(&targets, _maxRefGap, startPosition, lastPosition, _noDupes, _noAncestors,
                                                      false, // reverseStrand,
-                                                     true,  // unique
+                                                     _unique,
                                                      _onlyOrthologs);
 
     hal_size_t appendCount = 0;


### PR DESCRIPTION
In `hal2maf` if you export a block like 

```
a
s	simHuman_chr6.simHuman.chr6	1997	1	+	601863	G
s	Anc0.Anc0refChr1	1844	1	+	15316	G
s	Anc1.Anc1refChr0	1950	1	+	15968	G
s	simGorilla.simGorilla.chr6	1955	1	+	599081	G
s	simHuman_chr6.simHuman.chr6	2135	1	+	601863	G
s	simRat_chr6.simRat.chr6	2051	1	+	647215	G
```

When it comes to actually writing position `2051` on the reference, it'll skip it.  This comes from the invariant that every column is is visited once, and every column in the MAF is unique.  The problem is that this doesn't really help for pretty much any known application of MAF -- which usually wants to look at columns independently.  

It also makes cactus alignments look worse than multiz alignments, as the column would definitely appear twice in the latter. 

So this is a simple PR: just turn it off by default unless the (unrecommended `--unique` is used) in `hal2maf`.  The resulting maf should have much better-looking coverage in the browser.  