### PR TITLE
Fix calculation of newMaxSize in renameSequence

### DIFF
--- a/api/hdf5_impl/hdf5Genome.cpp
+++ b/api/hdf5_impl/hdf5Genome.cpp
@@ -744,7 +744,9 @@ void Hdf5Genome::rename(const string &newName) {
 
 void Hdf5Genome::renameSequence(const string &oldName, size_t index, const string &newName) {
     if (oldName.size() < newName.size()) {
-        resizeNameArray(newName.size());
+        size_t currentMaxSize = _sequenceNameArray.getDataType().getSize();
+        size_t newMaxSize = currentMaxSize + (newName.size() - oldName.size());
+        resizeNameArray(newMaxSize);
     }
     char *arrayBuffer = _sequenceNameArray.getUpdate(index);
     strcpy(arrayBuffer, newName.c_str());


### PR DESCRIPTION

## Issue

In `Hdf5Genome::renameSequence`, the relative size of the old and new sequence names are checked (in [lines 746-748 of hdf5Genome.cpp](https://github.com/ComparativeGenomicsToolkit/hal/blob/0c45d41210e95beff0ee5020d460fdb002297f75/api/hdf5_impl/hdf5Genome.cpp#L746-L748)), and if the new name is longer than the old name, the `SEQNAME_ARRAY` is resized to accommodate the new name.

However, the `newMaxSize` parameter of `Hdf5Genome::resizeNameArray` is currently being set to the size of the new name, which in most cases is much smaller than the `SEQNAME_ARRAY`. 

When `Hdf5Genome::resizeNameArray` checks this `newMaxSize` value against the `currentMaxSize` (in [line 757 of hdf5Genome.cpp](https://github.com/ComparativeGenomicsToolkit/hal/blob/0c45d41210e95beff0ee5020d460fdb002297f75/api/hdf5_impl/hdf5Genome.cpp#L757)), unless the new name is longer than the entire `SEQNAME_ARRAY`, it will think that the `newMaxSize` is smaller than the `currentMaxSize` and that there is no need to resize the `SEQNAME_ARRAY`.

As a result, the longer name is simply written to the `SEQNAME_ARRAY`, corrupting it.

For example, if you download the HAL file currently available [here](https://ftp.ensembl.org/pub/rapid-release/data_files/multi/hal_files/Rice_27-way_202208.hal), and output the sequence names of Oryza brachyantha to a file ...
```bash
halStats --sequences oryza_brachyantha.Oryza_brachyantha.v1.4b Rice_27-way_202208.hal \
    | tr , '\n' > eg_obra_seqnames_before.txt
```
... the file should list 7,485 numeric sequence names.

Given a HAL sequence rename file (e.g. `eg_obra_rename_file.tsv`) with the following contents ...
```
68370	super4879
```
... it is possible to rename this sequence:
```bash
halRenameSequences Rice_27-way_202208.hal oryza_brachyantha.Oryza_brachyantha.v1.4b eg_obra_rename_file.tsv
```

However, after listing the O. brachyantha sequence names again ...
```bash
halStats --sequences oryza_brachyantha.Oryza_brachyantha.v1.4b Rice_27-way_202208.hal \
    | tr , '\n' > eg_obra_seqnames_after.txt
```

... the `diff` between `eg_obra_seqnames_before.txt` and `eg_obra_seqnames_after.txt` looks like this:
```diff
4855,4856c4855,4856
< 68370
< 68371
---
> super4879
> 79
```
Sequence `68370` has been correctly renamed to `super4879`, but sequence `68371` appears to have been renamed to `79`. The `SEQIDX_ARRAY` for the O. brachyantha genome was unchanged by this test run of `halRenameSequences`, so it seems quite likely that the apparent new name of `68371` is really the tail end of `super4879`.

## Changes

This PR changes the calculation of the `newMaxSize` value in `Hdf5Genome::renameSequence` so that it is the expected size of the full `SEQNAME_ARRAY` after the requested name change.

## Testing

Repeating the steps above after applying the changes in this PR, the `diff` between `eg_obra_seqnames_before.txt` and `eg_obra_seqnames_after.txt` looks like this:
```diff
4855c4855
< 68370
---
> super4879
```