### PR TITLE
fix off-by-1 bug when resizing name array

### DIFF
--- a/api/hdf5_impl/hdf5Genome.cpp
+++ b/api/hdf5_impl/hdf5Genome.cpp
@@ -744,7 +744,7 @@ void Hdf5Genome::rename(const string &newName) {
 
 void Hdf5Genome::renameSequence(const string &oldName, size_t index, const string &newName) {
     if (oldName.size() < newName.size()) {
-        resizeNameArray(newName.size());
+        resizeNameArray(newName.size() + 1);
     }
     char *arrayBuffer = _sequenceNameArray.getUpdate(index);
     strcpy(arrayBuffer, newName.c_str());
@@ -769,7 +769,7 @@ void Hdf5Genome::resizeNameArray(size_t newMaxSize) {
         } catch (H5::Exception &) {
         }
 
-        _sequenceNameArray.create(&_group, sequenceNameArrayName, Hdf5Sequence::nameDataType(newMaxSize + 1), numSequences,
+        _sequenceNameArray.create(&_group, sequenceNameArrayName, Hdf5Sequence::nameDataType(newMaxSize), numSequences,
                                   &_dcprops, _numChunksInArrayBuffer);
         for (size_t i = 0; i < numSequences; i++) {
             char *arrayBuffer = _sequenceNameArray.getUpdate(i);


### PR DESCRIPTION
All credit to #266 for finding this bug and its solution.

The core issue seems to be using C++ string lengths and C-style array lengths (which include the '\0' char) interchangeably, which causes an off-by-1 bug in certain cases.

I'm opting for this fix (hopefully it's ok!) instead of the one from the PR as it better fits the semantics of the `resizeNameArray()` function (and it still allocates the +1 for the C string within the hdf5 structure). 