### PR TITLE
Fix hdf5 chunk scaling heuristic for bottom segments

### DIFF
--- a/api/hdf5_impl/hdf5Genome.cpp
+++ b/api/hdf5_impl/hdf5Genome.cpp
@@ -311,7 +311,7 @@ void Hdf5Genome::setGenomeBottomDimensions(const vector<Sequence::UpdateInfo> &b
     hsize_t chunk;
     _dcprops.getChunk(1, &chunk);
     double scale = numChildren < 10 ? 1. : 10. / numChildren;
-    chunk *= scale;
+    chunk = (hsize_t)max(1., scale * chunk);
     DSetCreatPropList botDC;
     botDC.copy(_dcprops);
     botDC.setChunk(1, &chunk);


### PR DESCRIPTION
There's some old logic in there that adapts the internal hdf5 chunk size relative to the size of the bottom segment (which is proportional to number of children).  And now that the number of children is uncapped (#304), the chunk scaling can get to 0 for huge values (~5000?) resulting in `halAppendCactusSubtree` crashing with
```
  #000: ../../../src/H5Pdcpl.c line 2004 in H5Pset_chunk(): all chunk dimensions must be positive
    major: Invalid arguments to routine
    minor: Out of range
```
The fix here is to simply clamp it at 1. 