### PR TITLE
fix hdf5 14.4+ runtime errors by relaxing new integrity check

### DIFF
--- a/api/hdf5_impl/hdf5Alignment.cpp
+++ b/api/hdf5_impl/hdf5Alignment.cpp
@@ -130,9 +130,9 @@ void Hdf5Alignment::defineOptions(CLParser *parser, unsigned mode) {
 
 /* initialize class from options */
 void Hdf5Alignment::initializeFromOptions(const CLParser *parser) {
-    _cprops.copy(H5::FileCreatPropList::DEFAULT);
-    _dcprops.copy(H5::DSetCreatPropList::DEFAULT);
-    _aprops.copy(H5::FileAccPropList::DEFAULT);
+    _cprops.copy(hdf5DefaultFileCreatPropList());
+    _dcprops.copy(hdf5DefaultDSetCreatPropList());
+    _aprops.copy(hdf5DefaultFileAccPropList());
     _inMemory = parser->getFlagAlt("hdf5InMemory", "inMemory");
     if ((_mode & CREATE_ACCESS) || (_mode & WRITE_ACCESS)) {
         // these are only available on create

--- a/api/impl/halAlignmentInstance.cpp
+++ b/api/impl/halAlignmentInstance.cpp
@@ -51,6 +51,7 @@ const H5::FileAccPropList &hal::hdf5DefaultFileAccPropList() {
         hid_t fapl_id = H5Pcreate(H5P_FILE_ACCESS);
         H5Pset_relax_file_integrity_checks(fapl_id, H5F_RFIC_ALL);
         fileAccessProps.copy(H5::FileAccPropList(fapl_id));
+        H5Pclose(fapl_id);
 #else
         fileAccessProps.copy(H5::FileAccPropList::DEFAULT);
 #endif

--- a/api/impl/halAlignmentInstance.cpp
+++ b/api/impl/halAlignmentInstance.cpp
@@ -42,7 +42,18 @@ const H5::FileAccPropList &hal::hdf5DefaultFileAccPropList() {
     static bool initialize = false;
     static H5::FileAccPropList fileAccessProps;
     if (not initialize) {
+#if H5_VERSION_GE(1, 14, 4)
+        // hdf5 stopped working with HAL in 1.14.4
+        // haven't had time to dig too deep but it seems like there's some new strictness
+        // about metadata checksums or unused bits or something
+        // luckily we can turn off using this (C-only) API call
+        // https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gafa8e677af3200e155e9208522f8e05c0        
+        hid_t fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+        H5Pset_relax_file_integrity_checks(fapl_id, H5F_RFIC_ALL);
+        fileAccessProps.copy(H5::FileAccPropList(fapl_id));
+#else
         fileAccessProps.copy(H5::FileAccPropList::DEFAULT);
+#endif
         fileAccessProps.setCache(Hdf5Alignment::DefaultCacheMDCElems, Hdf5Alignment::DefaultCacheRDCElems,
                                  Hdf5Alignment::DefaultCacheRDCBytes, Hdf5Alignment::DefaultCacheW0);
         initialize = true;


### PR DESCRIPTION
For some reason, HAL gives cryptic runtime errors when built against HDF5 v1.14.5.  This is apparently due to some [new integrity checks introduced in v1.14.4](https://support.hdfgroup.org/documentation/hdf5/latest/group___f_a_p_l.html#gafa8e677af3200e155e9208522f8e05c0), which can fortunately be turned off with the method in the link.  

This PR does just that which seems to fix the problems.  While I'm mildly curious as to what exactly HAL is doing to upset the new HDF5, the documentation is so poor that I'm not really sure where to start... 

Thanks @benedictpaten and @diekhans 