### PR TITLE
Add option to toggle compression codec

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Installation
 ### Requirements
 * gcc 4.2 or newer
 * git
+* liblz4-dev and libzstd-dev (for LZ4 and Zstd compression support)
 
 ### Downloading HAL
 
@@ -104,6 +105,22 @@ From the parent directory of where you want HAL installed:
 
     If you get undefined functions base on string type with errors about
     `std::__cxx11::basic_string` vs `std::basic_string`.
+
+#### LZ4 and Zstd compression libraries
+
+HAL supports LZ4 and Zstd as alternative HDF5 compression codecs (see `--hdf5Codec` below).
+
+* Using apt (Ubuntu/Debian):
+
+      sudo apt install liblz4-dev libzstd-dev
+
+* Using [MacPorts](http://www.macports.org/):
+
+      sudo port install lz4 zstd
+
+* Using [Homebrew](https://brew.sh/):
+
+      brew install lz4 zstd
 
 #### sonLib
 
@@ -181,10 +198,16 @@ HAL Tools
 *Detailed command line options can be obtained by running each tool with the `--help` option.*
 
 
-Two stored formats are included with HAL: `HDF5` and `mmap`.  HDF5 is standard container format for larger data sets with good compression characteristics .  The `mmap` format stores the raw data structures in a file, which is access by mapping in into memory using the `mmap` system call.  HAL files in the `mmap` format a considerably bigger but often much faster to access.  The `halExtract` command can be used to copy between formats.
+Two stored formats are included with HAL: `HDF5` and `mmap`.  HDF5 is standard container format for larger data sets with good compression characteristics .  The `mmap` format stores the raw data structures in a file, which is access by mapping in into memory using the `mmap` system call.  HAL files in the `mmap` format a considerably bigger but often much faster to access.  The `halExtract` command can be used to copy between formats and compression codecs.  For example, to convert an existing HAL file to use Zstd compression:
+
+    halExtract --hdf5Codec zstd input.hal output.hal
 
 
 All HAL tools compiled with HDF5 support expose some caching parameters.  Tools that create HAL files also include chunking and compression parameters.  In most cases, the default values of these options will suffice.
+
+`--hdf5Codec <value>:`   Compression codec for HDF5 datasets.  Options are `deflate` (gzip, the default), `lz4`, `zstd`, and `none`.  **LZ4** offers the fastest decompression but larger files.  **Zstd** provides the best balance: smaller files than deflate with faster decompression.  **Deflate** is the original codec and is compatible with any HDF5 installation.  LZ4 and Zstd filters are compiled into HAL, so no external HDF5 plugins are needed for HAL tools to read these files.  External tools (e.g. `h5dump`, `h5repack`) will require the appropriate [HDF5 filter plugin](https://github.com/HDFGroup/hdf5_plugins) to be installed.  [default = deflate]
+
+`--hdf5Compression <value>:`   Compression level.  For deflate: 0 (none) to 9 (max).  For zstd: 1 to 22.  Ignored for lz4.  Higher levels produce smaller files at the cost of slower *compression* (file creation), but decompression speed (file reading) is largely unaffected.  [default = 2]
 
 `--cacheBytes <value>:`    The maximum size of each array cache.  3 such caches can be allocated per genome in the alignment.
 

--- a/api/hdf5_impl/hdf5Alignment.cpp
+++ b/api/hdf5_impl/hdf5Alignment.cpp
@@ -10,6 +10,7 @@
 #include "halCommon.h"
 #include "halSequenceIterator.h"
 #include "hdf5Common.h"
+#include "hdf5Filters.h"
 #include "hdf5Genome.h"
 #include "hdf5MetaData.h"
 #include <algorithm>
@@ -40,6 +41,7 @@ const H5std_string Hdf5Alignment::VersionGroupName = "Verison";
 
 const hsize_t Hdf5Alignment::DefaultChunkSize = 1000;
 const hsize_t Hdf5Alignment::DefaultCompression = 2;
+const std::string Hdf5Alignment::DefaultCodec = "deflate";
 // to do: the C-api changed in 1.8 for metadata, and all signs point to the C++ api no longer working
 //        does this have any bearing on memory usage?
 const hsize_t Hdf5Alignment::DefaultCacheMDCElems = 113;
@@ -107,8 +109,10 @@ void Hdf5Alignment::defineOptions(CLParser *parser, unsigned mode) {
         parser->addOption("hdf5Chunk", "hdf5 chunk size", DefaultChunkSize);
         parser->addOption("chunk", "obsolete name for --hdf5Chunk ", DefaultChunkSize);
 
-        parser->addOption("hdf5Compression", "hdf5 compression factor [0:none - 9:max]", DefaultCompression);
+        parser->addOption("hdf5Compression", "hdf5 compression factor [0:none - 9:max for deflate/zstd, ignored for lz4]", DefaultCompression);
         parser->addOption("deflate", "obsolete name for --hdf5Compression", DefaultCompression);
+
+        parser->addOption("hdf5Codec", "compression codec: deflate (default), lz4, zstd, none", DefaultCodec);
     }
     parser->addOption("hdf5CacheMDC", "number of metadata slots in hdf5 cache", DefaultCacheMDCElems);
     parser->addOption("cacheMDC", "obsolete name for --hdf5CacheMDC ", DefaultCacheMDCElems);
@@ -138,7 +142,30 @@ void Hdf5Alignment::initializeFromOptions(const CLParser *parser) {
         // these are only available on create
         hsize_t chunk = parser->getOptionAlt<hsize_t>("hdf5Chunk", "chunk");
         _dcprops.setChunk(1, &chunk);
-        _dcprops.setDeflate(parser->getOptionAlt<hsize_t>("hdf5Compression", "deflate"));
+
+        string codec = parser->getOption<string>("hdf5Codec");
+        hsize_t level = parser->getOptionAlt<hsize_t>("hdf5Compression", "deflate");
+
+        // Remove any existing compression filter from default props before
+        // setting the requested one
+        _dcprops.setDeflate(0);
+        H5Premove_filter(_dcprops.getId(), H5Z_FILTER_ALL);
+
+        if (codec == "deflate") {
+            _dcprops.setDeflate(level);
+        } else if (codec == "lz4") {
+            halRegisterCompressors();
+            unsigned int cd_values[1] = {0}; // block size 0 = auto
+            H5Pset_filter(_dcprops.getId(), H5Z_FILTER_LZ4, H5Z_FLAG_MANDATORY, 1, cd_values);
+        } else if (codec == "zstd") {
+            halRegisterCompressors();
+            unsigned int cd_values[1] = {(unsigned int)level};
+            H5Pset_filter(_dcprops.getId(), H5Z_FILTER_ZSTD, H5Z_FLAG_MANDATORY, 1, cd_values);
+        } else if (codec == "none") {
+            // no compression
+        } else {
+            throw hal_exception("Unknown hdf5 codec: " + codec + ". Must be deflate, lz4, zstd, or none");
+        }
     }
     _aprops.setCache(
         parser->getOptionAlt<hsize_t>("hdf5CacheMDC", "cacheMDC"), parser->getOptionAlt<hsize_t>("hdf5CacheRDC", "cacheRDC"),

--- a/api/hdf5_impl/hdf5Alignment.h
+++ b/api/hdf5_impl/hdf5Alignment.h
@@ -14,6 +14,7 @@
 #include "hdf5MetaData.h"
 #include <H5Cpp.h>
 #include <map>
+#include <string>
 
 typedef struct _stTree stTree;
 
@@ -104,6 +105,7 @@ namespace hal {
       public:
         static const hsize_t DefaultChunkSize;
         static const hsize_t DefaultCompression;
+        static const std::string DefaultCodec;
         static const hsize_t DefaultCacheMDCElems;
         static const hsize_t DefaultCacheRDCElems;
         static const hsize_t DefaultCacheRDCBytes;

--- a/api/hdf5_impl/hdf5Filters.cpp
+++ b/api/hdf5_impl/hdf5Filters.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2024 by Glenn Hickey (hickey@soe.ucsc.edu)
+ * Copyright (C) 2012-2024 by UCSC Computational Genomics Lab
+ *
+ * Released under the MIT license, see LICENSE.txt
+ *
+ * LZ4 and Zstd HDF5 compression filters for HAL.
+ *
+ * Filter IDs follow the HDF5 registered filter convention:
+ *   LZ4:  32004 (compatible with nexusformat/HDF5-External-Filter-Plugins)
+ *   Zstd: 32015 (compatible with aparamon/HDF5Plugin-Zstandard)
+ *
+ * The cd_values parameter conventions match the standard implementations
+ * so files created by HAL can be read by any HDF5 tool with the
+ * corresponding plugin installed, and vice versa.
+ */
+
+#include "hdf5Filters.h"
+#include <cstdlib>
+#include <cstring>
+#include <lz4.h>
+#include <lz4hc.h>
+#include <zstd.h>
+
+/* ========================================================================
+ * LZ4 filter (ID 32004)
+ *
+ * cd_values[0] = blockSize (0 means use LZ4 default: 1<<17 = 128KB)
+ *
+ * Wire format per chunk (matches nexusformat convention):
+ *   [4 bytes big-endian] original (uncompressed) size
+ *   [rest]               LZ4 compressed data
+ * ======================================================================== */
+
+static size_t H5Z_filter_lz4(unsigned int flags, size_t cd_nelmts,
+                              const unsigned int cd_values[], size_t nbytes,
+                              size_t *buf_size, void **buf) {
+    if (flags & H5Z_FLAG_REVERSE) {
+        /* Decompress */
+        const char *src = (const char *)*buf;
+        if (nbytes < 4) return 0;
+
+        /* Read original size (big-endian 4 bytes) */
+        uint32_t origSize = ((uint32_t)(unsigned char)src[0] << 24) |
+                            ((uint32_t)(unsigned char)src[1] << 16) |
+                            ((uint32_t)(unsigned char)src[2] << 8)  |
+                            ((uint32_t)(unsigned char)src[3]);
+
+        void *outbuf = malloc(origSize);
+        if (!outbuf) return 0;
+
+        int decompressed = LZ4_decompress_safe(src + 4, (char *)outbuf,
+                                               (int)(nbytes - 4), (int)origSize);
+        if (decompressed < 0) {
+            free(outbuf);
+            return 0;
+        }
+
+        free(*buf);
+        *buf = outbuf;
+        *buf_size = origSize;
+        return (size_t)origSize;
+    } else {
+        /* Compress */
+        const char *src = (const char *)*buf;
+        int srcSize = (int)nbytes;
+        int maxDst = LZ4_compressBound(srcSize);
+        void *outbuf = malloc(4 + maxDst);
+        if (!outbuf) return 0;
+
+        /* Write original size as big-endian 4 bytes */
+        char *dst = (char *)outbuf;
+        dst[0] = (char)((nbytes >> 24) & 0xFF);
+        dst[1] = (char)((nbytes >> 16) & 0xFF);
+        dst[2] = (char)((nbytes >> 8)  & 0xFF);
+        dst[3] = (char)((nbytes)       & 0xFF);
+
+        int level = (cd_nelmts > 1 && cd_values[1] > 0) ? (int)cd_values[1] : 0;
+        int compressed;
+        if (level > 0) {
+            compressed = LZ4_compress_HC(src, dst + 4, srcSize, maxDst, level);
+        } else {
+            compressed = LZ4_compress_default(src, dst + 4, srcSize, maxDst);
+        }
+        if (compressed <= 0) {
+            free(outbuf);
+            return 0;
+        }
+
+        free(*buf);
+        *buf = outbuf;
+        *buf_size = 4 + compressed;
+        return 4 + (size_t)compressed;
+    }
+}
+
+static const H5Z_class2_t H5Z_LZ4_class = {
+    H5Z_CLASS_T_VERS,      /* H5Z_class_t version */
+    H5Z_FILTER_LZ4,        /* Filter id number */
+    1,                      /* encoder_present flag */
+    1,                      /* decoder_present flag */
+    "lz4",                  /* Filter name for debugging */
+    NULL,                   /* The "can apply" callback */
+    NULL,                   /* The "set local" callback */
+    H5Z_filter_lz4         /* The actual filter function */
+};
+
+/* ========================================================================
+ * Zstd filter (ID 32015)
+ *
+ * cd_values[0] = compression level (default ZSTD_CLEVEL_DEFAULT = 3)
+ *
+ * Wire format: raw zstd frame (self-describing, includes original size).
+ * This matches the aparamon/HDF5Plugin-Zstandard convention.
+ * ======================================================================== */
+
+static size_t H5Z_filter_zstd(unsigned int flags, size_t cd_nelmts,
+                               const unsigned int cd_values[], size_t nbytes,
+                               size_t *buf_size, void **buf) {
+    if (flags & H5Z_FLAG_REVERSE) {
+        /* Decompress */
+        const void *src = *buf;
+        unsigned long long origSize = ZSTD_getFrameContentSize(src, nbytes);
+        if (origSize == ZSTD_CONTENTSIZE_UNKNOWN || origSize == ZSTD_CONTENTSIZE_ERROR) {
+            /* Fall back: allocate a generous buffer */
+            origSize = nbytes * 8;
+        }
+
+        void *outbuf = malloc((size_t)origSize);
+        if (!outbuf) return 0;
+
+        size_t decompressed = ZSTD_decompress(outbuf, (size_t)origSize, src, nbytes);
+        if (ZSTD_isError(decompressed)) {
+            free(outbuf);
+            return 0;
+        }
+
+        free(*buf);
+        *buf = outbuf;
+        *buf_size = decompressed;
+        return decompressed;
+    } else {
+        /* Compress */
+        int level = (cd_nelmts > 0) ? (int)cd_values[0] : ZSTD_CLEVEL_DEFAULT;
+        size_t maxDst = ZSTD_compressBound(nbytes);
+        void *outbuf = malloc(maxDst);
+        if (!outbuf) return 0;
+
+        size_t compressed = ZSTD_compress(outbuf, maxDst, *buf, nbytes, level);
+        if (ZSTD_isError(compressed)) {
+            free(outbuf);
+            return 0;
+        }
+
+        free(*buf);
+        *buf = outbuf;
+        *buf_size = compressed;
+        return compressed;
+    }
+}
+
+static const H5Z_class2_t H5Z_ZSTD_class = {
+    H5Z_CLASS_T_VERS,      /* H5Z_class_t version */
+    H5Z_FILTER_ZSTD,       /* Filter id number */
+    1,                      /* encoder_present flag */
+    1,                      /* decoder_present flag */
+    "zstd",                 /* Filter name for debugging */
+    NULL,                   /* The "can apply" callback */
+    NULL,                   /* The "set local" callback */
+    H5Z_filter_zstd         /* The actual filter function */
+};
+
+/* ========================================================================
+ * Registration
+ * ======================================================================== */
+
+void halRegisterCompressors(void) {
+    static bool registered = false;
+    if (registered) return;
+
+    H5Zregister(&H5Z_LZ4_class);
+    H5Zregister(&H5Z_ZSTD_class);
+    registered = true;
+}

--- a/api/hdf5_impl/hdf5Filters.h
+++ b/api/hdf5_impl/hdf5Filters.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 by Glenn Hickey (hickey@soe.ucsc.edu)
+ * Copyright (C) 2012-2024 by UCSC Computational Genomics Lab
+ *
+ * Released under the MIT license, see LICENSE.txt
+ *
+ * LZ4 and Zstd HDF5 compression filters for HAL.
+ * These are registered via H5Zregister() so they are compiled directly
+ * into HAL and do not require external HDF5 plugin installation.
+ */
+
+#ifndef _HDF5FILTERS_H
+#define _HDF5FILTERS_H
+
+#include <hdf5.h>
+
+/* Standard registered filter IDs */
+#define H5Z_FILTER_LZ4  ((H5Z_filter_t)32004)
+#define H5Z_FILTER_ZSTD ((H5Z_filter_t)32015)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Register LZ4 and Zstd filters with the HDF5 library.
+ * Must be called before any datasets using these filters are created or read.
+ * Safe to call multiple times. */
+void halRegisterCompressors(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _HDF5FILTERS_H */

--- a/api/impl/halAlignmentInstance.cpp
+++ b/api/impl/halAlignmentInstance.cpp
@@ -9,6 +9,7 @@
 #include "halCLParser.h"
 #include "halCommon.h"
 #include "hdf5Alignment.h"
+#include "hdf5Filters.h"
 #include "mmapAlignment.h"
 #include <cassert>
 #include <cstdlib>
@@ -42,6 +43,8 @@ const H5::FileAccPropList &hal::hdf5DefaultFileAccPropList() {
     static bool initialize = false;
     static H5::FileAccPropList fileAccessProps;
     if (not initialize) {
+        // Register LZ4/Zstd filters so we can read files using them
+        halRegisterCompressors();
 #if H5_VERSION_GE(1, 14, 4)
         // hdf5 stopped working with HAL in 1.14.4
         // haven't had time to dig too deep but it seems like there's some new strictness

--- a/include.mk
+++ b/include.mk
@@ -55,7 +55,7 @@ endif
 CFLAGS += -I${sonLibDir}
 CXXFLAGS += -I${sonLibDir} ${CXX_ABI_DEF} -std=c++11 -Wno-sign-compare
 
-LDLIBS += ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
+LDLIBS += ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a -llz4 -lzstd
 LIBDEPENDS += ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
 
 # hdf5 compilation is done through its wrappers.  See README.md for discussion of


### PR DESCRIPTION
For 12-mammal test hal:
```
deflate (default): 37G
zstd: 28G
```

zstd is also faster to decompress.  The smaller file size lowers memory footprint and speeds up most commands by at least a little (hoping for bigger speed payoffs on giant files).  

So I'm adding a CLI option `--hdf5Codec` that lets you toggle between codecs (deflate/zstd/lz4/none).  lz4 is by far the fastest, but comes in at too high a space cost (file size way *bigger* than deflate) to recommend so far.  So zstd looks like the winner.  I'm leaving the default as is so as not to break compatibility (though I will probably bump cactus to use zstd by default in its output).  

The new API will transparently read files with any of these types of compression (and all tools will get the new option to toggle writing).  

But this also means that old hal binaries will *not* be able to read files generated with the api if `--hdf5Codec zstd` or `--hdf5Codec lz4` is used.

Will not merge until I'm sure the build properly integrates into Cactus.