### PR TITLE
Update phast

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,31 +131,32 @@ Those without the UCSC genome browser already installed locally will probably fi
 
 #### Optional support of PhyloP evolutionary constraint annotation
 
-PhyloP is part of the [Phast Package](http://compgen.bscb.cornell.edu/phast/), and can be used to test for genomic positions that are under selective pressure.  We are working on prototype support for running PhyloP on HAL files.  In order to enable this support, Phast must be installed.  We recommend downloading the latest source using Subversion.
+[PhyloP](http://compgen.bscb.cornell.edu/phast/) (part of the Phast package) tests for genomic positions under selective pressure. HAL ships a `halPhyloP` binary that runs phyloP directly against a HAL file; building it requires Phast (v1.9.7 or newer) plus its system dependencies.
+
+> Most users at whole-genome / many-species scale should use `cactus-phast` from [Cactus](https://github.com/ComparativeGenomicsToolkit/cactus) instead — it parallelizes the workflow over a cluster and avoids halPhyloP's serial-only execution. See the [phyloP Conservation section in the Cactus docs](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/progressive.md#phylop-conservation). The instructions below build `halPhyloP` for users who want to invoke phast against a HAL directly.
 
 From the same parent directory where you downloaded HAL:
 
-* First install CLAPACK (Linux only)
+* Install Phast's system dependencies (Linux):
 
-    `wget http://www.netlib.org/clapack/clapack.tgz`
-    `tar -xvzf clapack.tgz`
-    `mv CLAPACK-3.2.1 clapack`
-    `cd clapack`
-    `cp make.inc.example make.inc && make f2clib && make blaslib && make lib`
-    `export CLAPACKPATH=$(pwd)` `
-    `cd ..`
+    `sudo apt-get install libblas-dev liblapack-dev libpcre3-dev libgfortran-13-dev cmake`
 
-*  Install Phast (Mac or Linux)
+  (substitute `libgfortran-N-dev` with whatever gcc version your system has; the package ships both `libgfortran.a` and `libquadmath.a`). On macOS the Accelerate framework supplies BLAS/LAPACK; only PCRE needs to be installed (`brew install pcre`).
+
+*  Install Phast (Mac or Linux):
 
      `git clone https://github.com/CshlSiepelLab/phast.git`
      `cd phast`
-     `git checkout 85f7ed179dd097a86ba4added22d571785cc3e1d`
-     `cd src && make`
-     `cd ../..`
+     `git checkout v1.9.7`
+     `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
+     `cmake --build build -j`
+     `cd ..`
 
-* Before building HAL
+* Before building HAL:
 
      `export ENABLE_PHYLOP=1`
+
+  By default `hal/include.mk` looks for `${PHAST}/build/src/lib/libphast.a` (where `${PHAST}` defaults to `${rootDir}/../phast`). Override `PHAST` and/or `PHAST_BUILD_DIR` to point elsewhere.
 
 Special thanks to Melissa Jane Hubiz and Adam Siepel from Cornell University for their work on extending their tools to work with HAL.
 
@@ -362,22 +363,17 @@ Point mutations can optionally be written using the `--snpFile <file>` option.  
 
 ### Constrained Element Prediction
 
-(Under development)
+> ⚠ **`halPhyloPTrain.py` and `halPhyloPMP.py` are no longer maintained.** They were prototypes for running phyloP directly against a HAL file via Python multiprocessing on a single machine; both are stale and not recommended. The supported workflow is to export the alignment to MAF with `cactus-hal2maf` and run phyloP via `cactus-phast`, which is Toil-parallelized over a cluster, ships hardened against the numerical-breakdown failure modes the prototypes never handled, and supports `--root` (clade-specific models) and `--subtree` (lineage-specific LRT) tracks. See the [phyloP Conservation section of the Cactus docs](https://github.com/ComparativeGenomicsToolkit/cactus/blob/master/doc/progressive.md#phylop-conservation).
 
-PhyloP is part of the [Phast Package](http://compgen.bscb.cornell.edu/phast/), and can be used to test for genomic positions that are under selective pressure.  We are working on prototype support for running PhyloP on HAL files.
+PhyloP is part of the [Phast Package](http://compgen.bscb.cornell.edu/phast/) and is used to test for genomic positions under selective pressure. The `halPhyloP` binary built from this repository (with `ENABLE_PHYLOP=1`) runs phyloP directly against a HAL file; it remains useful for small / single-machine analyses but is single-threaded and lacks the chunked I/O and error-tolerance of the cactus-phast pipeline.
 
-* Train a neutral model
+* Train a neutral model:
 
-     See `halPhyloPTrain.py`
+     See `halPhyloPTrain.py` (deprecated — prefer `cactus-phast --mode phyloFit`).
 
-* Detect constrained elements
+* Detect constrained elements:
 
-     See `halPhyloPMP.py`
-
-* Examples:
-
-	 `halPhyloPTrain.py mammals.hal human neutralRegions.bed neutralModel.mod --numProc 12`
-	 `halTreePhyloP.py mammals.hal neutralModel.mod outdir --bigWig --numProc 12`
+     See `halPhyloPMP.py` (deprecated — prefer `cactus-phast --mode phyloP`).
 
 Special thanks to Melissa Jane Hubiz and Adam Siepel from Cornell University for their work on extending their tools to work with HAL.
 

--- a/include.mk
+++ b/include.mk
@@ -58,6 +58,11 @@ CXXFLAGS += -I${sonLibDir} ${CXX_ABI_DEF} -std=c++11 -Wno-sign-compare
 LDLIBS += ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
 LIBDEPENDS += ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
 
+# hdf5Filters.cpp implements custom HDF5 zstd/lz4 filters that reference
+# libzstd / liblz4. h5c++'s wrapper config doesn't pull them in, so add them
+# here for every binary that links libHal.a.
+LDLIBS += -lzstd -llz4
+
 # hdf5 compilation is done through its wrappers.  See README.md for discussion of
 # h5prefix
 CXX = h5c++ ${h5prefix}
@@ -75,25 +80,33 @@ ifndef TARGETOS
   TARGETOS := $(shell uname -s)
 endif
 
-#  Defaults to local Linux install (phast and clapack sister dirs to hal/)
-# (note CLAPACKPATH not needed in Mac)
+#  Defaults to local Linux install (phast as sister dir to hal/)
 ifeq (${PHAST},)
     PHAST=${rootDir}/../phast
 endif
-ifeq (${CLAPACKPATH},)
-    CLAPACKPATH=${rootDir}/../clapack
+
+# phast v1.9.3+ moved to a cmake build and dropped the bundled CLAPACK and PCRE.
+# libphast.a now lives in <build>/src/lib/ (default ${PHAST}/build/src/lib),
+# system BLAS/LAPACK/PCRE supply what CLAPACK + bundled pcre used to provide.
+ifeq (${PHAST_BUILD_DIR},)
+    PHAST_BUILD_DIR=${PHAST}/build
 endif
 
 # pointing at both ${PHAST}/include/phast and ${PHAST}/include allows compiling
 # with v1.6 or v1.5.  However, only do the includes where needed, to avoid
 # include file name conflicts.
 ifeq ($(TARGETOS), Darwin)
-    PHASTCXXFLAGS += -DENABLE_PHYLOP -I${PHAST}/include/phast -I${PHAST}/include -I${PHAST}/src/lib/pcre -DVECLIB
-    LDLIBS += -L${PHAST}/lib -lphast -lc -framework Accelerate
+    PHASTCXXFLAGS += -DENABLE_PHYLOP -I${PHAST}/include/phast -I${PHAST}/include -DVECLIB
+    LDLIBS += -L${PHAST_BUILD_DIR}/src/lib -lphast -lpcre -lc -framework Accelerate
 else
-    F2CPATH=${CLAPACKPATH}/F2CLIBS
-    PHASTCXXFLAGS += -DENABLE_PHYLOP -I${PHAST}/include/phast -I${PHAST}/include -I${PHAST}/src/lib/pcre -I${CLAPACKPATH}/INCLUDE -I${F2CPATH}
-    LDLIBS += -L${PHAST}/lib -lphast -L${CLAPACKPATH} -L${F2CPATH} -llapack -ltmg -lblaswr -lf2c 
+    PHASTCXXFLAGS += -DENABLE_PHYLOP -DPHAST_USE_SYSTEM_LAPACK -fopenmp -I${PHAST}/include/phast -I${PHAST}/include
+    # Match cactus's downloadPhast static-linking strategy: link libblas.a /
+    # liblapack.a from libblas-dev / liblapack-dev, libpcre.a from libpcre3-dev,
+    # and libgfortran.a from libgfortran-N-dev. The whole-archive isn't needed —
+    # the linker pulls only the symbols libphast.a actually references.
+    # phast v1.9.7 added OpenMP-parallelized tree likelihoods, so libphast.a
+    # has GOMP_/omp_ refs; -fopenmp links libgomp.
+    LDLIBS += -L${PHAST_BUILD_DIR}/src/lib -lphast -l:libpcre.a -l:liblapack.a -l:libblas.a -l:libgfortran.a -l:libquadmath.a -lgomp -lm -lpthread
 endif
 
 endif

--- a/phyloP/Makefile
+++ b/phyloP/Makefile
@@ -7,7 +7,7 @@ halPhyloP_objs = ${halPhyloP_srcs:%.cpp=${modObjDir}/%.o}
 srcs = ${halPhyloP_srcs}
 objs = ${srcs:%.cpp=${modObjDir}/%.o}
 depends = ${srcs:%.cpp=%.depend}
-progs =  ${binDir}/halPhyloP ${binDir}/halPhyloPTrain.py ${binDir}/halPhyloPMP.py ${binDir}/halTreePhyloP.py
+progs =  ${binDir}/halPhyloP ${binDir}/halTreePhyloP.py
 otherLibs = ${libHalLiftover}
 inclSpec += -I${rootDir}/liftover/inc ${PHASTCXXFLAGS}
 

--- a/phyloP/impl/halPhyloP.cpp
+++ b/phyloP/impl/halPhyloP.cpp
@@ -285,7 +285,8 @@ double PhyloP::pval(const ColumnIterator::ColumnMap *cmap) {
     if (_mod->subtree_root == NULL) {
         _mod->scale = 1;
         tm_set_subst_matrices(_mod);
-        null_lnl = col_compute_log_likelihood(_mod, _msa, 0, _colfitdata->fels_scratch[0]);
+        // phast v1.9.2 renamed col_compute_log_likelihood -> col_compute_scaled_log_likelihood.
+        null_lnl = col_compute_scaled_log_likelihood(_mod, _msa, 0, _colfitdata->fels_scratch[0]);
         vec_set(_colfitdata->params, 0, _colfitdata->init_scale);
         opt_newton_1d(col_likelihood_wrapper_1d, &_colfitdata->params->data[0], _colfitdata, &alt_lnl, sigfigs,
                       _colfitdata->lb->data[0], _colfitdata->ub->data[0], NULL, NULL, NULL);


### PR DESCRIPTION
Updates phast linking to work with latest phast release (cmake-basted).

Also, deprecate halPhyloP python scripts (but don't erase them).   But the recommended phylop interfeace is now cactus-phast. 